### PR TITLE
Update end-to-end-tests to use PR number instead of branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'v3'
 
+concurrency:
+  group: ${{ github.event_name }}-${{ github.ref }}
+
 jobs:
   test:
     name: Run tests & display coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
           COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_1: ${{ secrets.COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_1 }}
           COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_2: ${{ secrets.COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_2 }}
           COVERAGE_COMMENT_E2E_ACTION_REF: ${{ github.sha }}
-          COVERAGE_COMMENT_E2E_REPO_SUFFIX: ${{ github.head_ref }}
+          COVERAGE_COMMENT_E2E_REPO_SUFFIX: ${{ github.event.number }}
 
       - name: Coverage comment
         id: coverage_comment


### PR DESCRIPTION
This PR changes the end-to-end tests, to use the PR number instead of the name of the branch as the suffix for the created repo. This has several advantages:
- The name of the repo is not longer than the allowed maximum length.
- The name of the repo clearly indicates which PR it refers to.
- There is no chaos with branches of the same name from different repos.

Do we have to change anything for `push` or anything else @ewjoachim?