### PR TITLE
Introduce workflow_run event for Docker publish

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,10 +6,6 @@
 name: Publish Docker image
 
 on:
-  release:
-    types:
-      - published
-
   workflow_run:
     workflows: [CI]
     types: [completed]

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,14 +9,18 @@ on:
   release:
     types:
       - published
-  push:
-    branches:
-      - v3
+
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [v3]
 
 jobs:
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    # Check if the tests were successful and were launched by a push event
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v2


### PR DESCRIPTION
Closes #64 

With this change, the Docker Publish should only be executed if the tests were successful.