### PR TITLE
Fix CI problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
 
       - name: Install Poetry
         run: |
-          pipx install poetry
+          python3 -m pip install pipx
+          python3 -m pipx install poetry
 
       - name: Poetry caches
         uses: actions/cache@v2


### PR DESCRIPTION
This PR causes pipx to run with Python version `3.10` and not `3.8` as before, which has led to problems with CI.