### PR TITLE
Add more detailed text to the PR comment

### DIFF
--- a/coverage_comment/default.md.j2
+++ b/coverage_comment/default.md.j2
@@ -14,6 +14,11 @@ The coverage rate went from `{{ previous_coverage_rate | pct }}` to `{{ coverage
 {%- endif %}
 {%- endblock emoji_coverage -%}
 {%- else -%}
+{% block no_comparison_info -%}
+> **Note**
+> No coverage data of the default branch was found for comparison. A possible reason for this is that the coverage action has not yet run after a push event and the data is therefore not yet initialized.
+{%- endblock no_comparison_info %}
+
 {% block coverage_value_wording -%}
 The coverage rate is `{{ coverage.info.percent_covered | pct }}`.
 {%- endblock coverage_value_wording %}

--- a/coverage_comment/default.md.j2
+++ b/coverage_comment/default.md.j2
@@ -33,7 +33,11 @@ The branch rate is `{{ (coverage.info.covered_branches / coverage.info.num_branc
 {% endblock branch_coverage -%}
 
 {% block diff_coverage_wording -%}
+{%- if diff_coverage.total_num_lines > 0 -%}
 `{{ diff_coverage.total_percent_covered | pct }}` of new lines are covered.
+{%- else -%}
+_None of the new lines are part of the tested code. Therefore, there is no coverage data about them._
+{%- endif %}
 {%- endblock diff_coverage_wording %}
 
 {% block coverage_by_file -%}

--- a/coverage_comment/default.md.j2
+++ b/coverage_comment/default.md.j2
@@ -32,13 +32,15 @@ The branch rate is `{{ (coverage.info.covered_branches / coverage.info.num_branc
 {%- endif %}
 {% endblock branch_coverage -%}
 
-{% block diff_coverage_wording -%}
 {%- if diff_coverage.total_num_lines > 0 -%}
+{% block diff_coverage_wording -%}
 `{{ diff_coverage.total_percent_covered | pct }}` of new lines are covered.
-{%- else -%}
-_None of the new lines are part of the tested code. Therefore, there is no coverage data about them._
-{%- endif %}
 {%- endblock diff_coverage_wording %}
+{%- else -%}
+{% block diff_coverage_empty_wording -%}
+_None of the new lines are part of the tested code. Therefore, there is no coverage data about them._
+{%- endblock diff_coverage_empty_wording %}
+{%- endif %}
 
 {% block coverage_by_file -%}
 {%if diff_coverage.files -%}

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -120,6 +120,7 @@ def test_action__pull_request__store_comment(
 
     comment_file = pathlib.Path("python-coverage-comment-action.txt").read_text()
     assert comment == comment_file
+    assert "No coverage data of the default branch was found for comparison" in comment
     assert "The coverage rate is `86%`" in comment
     assert "`100%` of new lines are covered." in comment
     assert (

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -169,6 +169,32 @@ Missing lines: `5`
     assert result == expected
 
 
+def test_template__no_new_lines_with_coverage(coverage_obj):
+    diff_cov = coverage.DiffCoverage(
+        total_num_lines=0,
+        total_num_violations=0,
+        total_percent_covered=1.0,
+        num_changed_lines=39,
+        files={},
+    )
+
+    result = template.get_markdown_comment(
+        coverage=coverage_obj,
+        diff_coverage=diff_cov,
+        previous_coverage_rate=1.0,
+        base_template=template.read_template_file(),
+    )
+    expected = """## Coverage report
+The coverage rate went from `100%` to `75%` :arrow_down:
+The branch rate is `50%`.
+
+_None of the new lines are part of the tested code. Therefore, there is no coverage data about them._
+
+
+<!-- This comment was produced by python-coverage-comment-action -->"""
+    assert result == expected
+
+
 def test_template__no_branch_no_previous(coverage_obj_no_branch, diff_coverage_obj):
     result = template.get_markdown_comment(
         coverage=coverage_obj_no_branch,

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -177,6 +177,9 @@ def test_template__no_branch_no_previous(coverage_obj_no_branch, diff_coverage_o
         base_template=template.read_template_file(),
     )
     expected = """## Coverage report
+> **Note**
+> No coverage data of the default branch was found for comparison. A possible reason for this is that the coverage action has not yet run after a push event and the data is therefore not yet initialized.
+
 The coverage rate is `75%`.
 
 `80%` of new lines are covered.


### PR DESCRIPTION
Closes #51 
May be clearer in cases like #11

This PR does two things:
* If no comparison data was found, it generates an extra message in the PR comment (#51)
* I found the message "100% of new lines are covered" a bit misleading when there is no coverage information about any of the new lines (since they belong to README, config files or the like, for example). Therefore, this is replaced by another message in this case.