### PR TITLE
[New feature] Optional annotations for not covered lines on pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,9 @@ jobs:
     # If true, will run `coverage combine` before reading the `.coverage` file.
     MERGE_COVERAGE_FILES: false
 
+    # If true, will create an annotation on every line with missing coverage on a pull request.
+    ANNOTATE_MISSING_LINES: false
+
     # If true, produces more output. Useful for debugging.
     VERBOSE: false
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ jobs:
     # If true, will create an annotation on every line with missing coverage on a pull request.
     ANNOTATE_MISSING_LINES: false
 
+    # Only needed if ANNOTATE_MISSING_LINES is set to true. This parameter allows you to choose between
+    # notice, warning and error as annotation type. For more information look here:
+    # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message
+    ANNOTATION_TYPE: warning
+
     # If true, produces more output. Useful for debugging.
     VERBOSE: false
 

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,12 @@ inputs:
     description: >
       If true, will create an annotation on every line with missing coverage on a pull request.
     default: false
+  ANNOTATION_TYPE:
+    description: >
+      Only needed if ANNOTATE_MISSING_LINES is set to true. This parameter allows you to choose between
+      notice, warning and error as annotation type. For more information look here:
+      https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message
+    default: warning
   VERBOSE:
     description: >
       If true, produces more output. Useful for debugging.
@@ -82,4 +88,5 @@ runs:
     MINIMUM_ORANGE: ${{ inputs.MINIMUM_ORANGE }}
     MERGE_COVERAGE_FILES: ${{ inputs.MERGE_COVERAGE_FILES }}
     ANNOTATE_MISSING_LINES: ${{ inputs.ANNOTATE_MISSING_LINES }}
+    ANNOTATION_TYPE: ${{ inputs.ANNOTATION_TYPE }}
     VERBOSE: ${{ inputs.VERBOSE }}

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: >
       If true, will run `coverage combine` before reading the `.coverage` file.
     default: false
+  ANNOTATE_MISSING_LINES:
+    description: >
+      If true, will create an annotation on every line with missing coverage on a pull request.
+    default: false
   VERBOSE:
     description: >
       If true, produces more output. Useful for debugging.
@@ -77,4 +81,5 @@ runs:
     MINIMUM_GREEN: ${{ inputs.MINIMUM_GREEN }}
     MINIMUM_ORANGE: ${{ inputs.MINIMUM_ORANGE }}
     MERGE_COVERAGE_FILES: ${{ inputs.MERGE_COVERAGE_FILES }}
+    ANNOTATE_MISSING_LINES: ${{ inputs.ANNOTATE_MISSING_LINES }}
     VERBOSE: ${{ inputs.VERBOSE }}

--- a/coverage_comment/annotations.py
+++ b/coverage_comment/annotations.py
@@ -1,0 +1,18 @@
+from coverage_comment import coverage as coverage_module
+from coverage_comment import github
+
+MISSING_LINES_GROUP_TITLE = "Annotations of lines with missing coverage"
+
+
+def create_pr_annotations(annotation_type: str, coverage: coverage_module.Coverage):
+    github.send_workflow_command(
+        command="group", command_value=MISSING_LINES_GROUP_TITLE
+    )
+
+    for filename, file_coverage in coverage.files.items():
+        for missing_line in file_coverage.missing_lines:
+            github.create_missing_coverage_annotation(
+                annotation_type=annotation_type, file=filename, line=missing_line
+            )
+
+    github.send_workflow_command(command="endgroup", command_value="")

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -5,7 +5,7 @@ import sys
 
 import httpx
 
-from coverage_comment import comment_file, communication
+from coverage_comment import annotations, comment_file, communication
 from coverage_comment import coverage as coverage_module
 from coverage_comment import (
     files,
@@ -68,6 +68,11 @@ def action(
     if event_name in {"pull_request", "push"}:
         coverage = coverage_module.get_coverage_info(merge=config.MERGE_COVERAGE_FILES)
         if event_name == "pull_request":
+            if config.ANNOTATE_MISSING_LINES:
+                annotations.create_pr_annotations(
+                    annotation_type=config.ANNOTATION_TYPE, coverage=coverage
+                )
+
             return generate_comment(
                 config=config,
                 coverage=coverage,

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -8,6 +8,10 @@ class MissingEnvironmentVariable(Exception):
     pass
 
 
+class InvalidAnnotationType(Exception):
+    pass
+
+
 def path_below(path_str: str) -> pathlib.Path:
     try:
         return pathlib.Path(path_str).resolve().relative_to(pathlib.Path.cwd())
@@ -40,6 +44,7 @@ class Config:
     MINIMUM_ORANGE: float = 70.0
     MERGE_COVERAGE_FILES: bool = False
     ANNOTATE_MISSING_LINES: bool = False
+    ANNOTATION_TYPE: str = "warning"
     VERBOSE: bool = False
     # Only for debugging, not exposed in the action:
     FORCE_WORKFLOW_RUN: bool = False
@@ -64,6 +69,14 @@ class Config:
     @classmethod
     def clean_annotate_missing_lines(cls, value: str) -> bool:
         return str_to_bool(value)
+
+    @classmethod
+    def clean_annotation_type(cls, value: str) -> str:
+        if value not in {"notice", "warning", "error"}:
+            raise InvalidAnnotationType(
+                f"The annotation type {value} is not valid. Please choose from notice, warning or error"
+            )
+        return value
 
     @classmethod
     def clean_verbose(cls, value: str) -> bool:

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -39,6 +39,7 @@ class Config:
     MINIMUM_GREEN: float = 100.0
     MINIMUM_ORANGE: float = 70.0
     MERGE_COVERAGE_FILES: bool = False
+    ANNOTATE_MISSING_LINES: bool = False
     VERBOSE: bool = False
     # Only for debugging, not exposed in the action:
     FORCE_WORKFLOW_RUN: bool = False
@@ -58,6 +59,10 @@ class Config:
 
     @classmethod
     def clean_merge_coverage_files(cls, value: str) -> bool:
+        return str_to_bool(value)
+
+    @classmethod
+    def clean_annotate_missing_lines(cls, value: str) -> bool:
         return str_to_bool(value)
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -215,6 +215,65 @@ def coverage_obj_no_branch():
 
 
 @pytest.fixture
+def coverage_obj_many_missing_lines():
+    return coverage_module.Coverage(
+        meta=coverage_module.CoverageMetadata(
+            version="1.2.3",
+            timestamp=datetime.datetime(2000, 1, 1),
+            branch_coverage=True,
+            show_contexts=False,
+        ),
+        info=coverage_module.CoverageInfo(
+            covered_lines=7,
+            num_statements=10,
+            percent_covered=0.8,
+            missing_lines=12,
+            excluded_lines=0,
+            num_branches=2,
+            num_partial_branches=1,
+            covered_branches=1,
+            missing_branches=1,
+        ),
+        files={
+            "codebase/main.py": coverage_module.FileCoverage(
+                path="codebase/main.py",
+                executed_lines=[1, 2, 5, 6, 9],
+                missing_lines=[3, 7, 13, 21, 123],
+                excluded_lines=[],
+                info=coverage_module.CoverageInfo(
+                    covered_lines=5,
+                    num_statements=10,
+                    percent_covered=0.5,
+                    missing_lines=5,
+                    excluded_lines=0,
+                    num_branches=2,
+                    num_partial_branches=1,
+                    covered_branches=1,
+                    missing_branches=1,
+                ),
+            ),
+            "codebase/caller.py": coverage_module.FileCoverage(
+                path="codebase/caller.py",
+                executed_lines=[1, 2, 5],
+                missing_lines=[13, 21, 212],
+                excluded_lines=[],
+                info=coverage_module.CoverageInfo(
+                    covered_lines=3,
+                    num_statements=6,
+                    percent_covered=0.5,
+                    missing_lines=3,
+                    excluded_lines=0,
+                    num_branches=2,
+                    num_partial_branches=1,
+                    covered_branches=1,
+                    missing_branches=1,
+                ),
+            ),
+        },
+    )
+
+
+@pytest.fixture
 def diff_coverage_obj():
     return coverage_module.DiffCoverage(
         total_num_lines=5,

--- a/tests/end_to_end/repo/.github/workflows/ci.yml
+++ b/tests/end_to_end/repo/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         uses: py-cov-action/python-coverage-comment-action@__ACTION_REF__
         with:
           GITHUB_TOKEN: ${{ github.token }}
+          ANNOTATE_MISSING_LINES: true
+          ANNOTATION_TYPE: notice
           VERBOSE: "true"
 
       - name: Store Pull Request comment to be posted

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -292,3 +292,38 @@ def test_set_output(output_file):
     github.set_output(github_output=output_file, foo=True)
 
     assert output_file.read_text() == "foo=true\n"
+
+
+def test_send_workflow_command(capsys):
+    github.send_workflow_command(
+        command="foo", command_value="bar", file="main.py", line="1", title="someTitle"
+    )
+    output = capsys.readouterr()
+    assert output.out.strip() == "::foo file=main.py,line=1,title=someTitle::bar"
+
+
+def test_send_workflow_command_no_kwargs(capsys):
+    github.send_workflow_command(command="group", command_value="title")
+    output = capsys.readouterr()
+    assert output.out.strip() == "::group::title"
+
+
+def test_create_missing_coverage_annotation(capsys):
+    github.create_missing_coverage_annotation(
+        annotation_type="warning", file="test.py", line=42
+    )
+    output = capsys.readouterr()
+    assert (
+        output.out.strip()
+        == "::warning file=test.py,line=42::This line has no coverage"
+    )
+
+
+def test_create_missing_coverage_annotation__annotation_type(capsys):
+    github.create_missing_coverage_annotation(
+        annotation_type="error", file="test.py", line=42
+    )
+    output = capsys.readouterr()
+    assert (
+        output.out.strip() == "::error file=test.py,line=42::This line has no coverage"
+    )

--- a/tests/unit/test_annotations.py
+++ b/tests/unit/test_annotations.py
@@ -1,0 +1,31 @@
+from coverage_comment import annotations
+
+
+def test_annotations(coverage_obj, capsys):
+    annotations.create_pr_annotations(annotation_type="warning", coverage=coverage_obj)
+
+    expected = """::group::Annotations of lines with missing coverage
+::warning file=codebase/code.py,line=7::This line has no coverage
+::warning file=codebase/code.py,line=9::This line has no coverage
+::endgroup::"""
+    output = capsys.readouterr()
+    assert output.out.strip() == expected
+
+
+def test_annotations_several_files(coverage_obj_many_missing_lines, capsys):
+    annotations.create_pr_annotations(
+        annotation_type="notice", coverage=coverage_obj_many_missing_lines
+    )
+
+    expected = """::group::Annotations of lines with missing coverage
+::notice file=codebase/main.py,line=3::This line has no coverage
+::notice file=codebase/main.py,line=7::This line has no coverage
+::notice file=codebase/main.py,line=13::This line has no coverage
+::notice file=codebase/main.py,line=21::This line has no coverage
+::notice file=codebase/main.py,line=123::This line has no coverage
+::notice file=codebase/caller.py,line=13::This line has no coverage
+::notice file=codebase/caller.py,line=21::This line has no coverage
+::notice file=codebase/caller.py,line=212::This line has no coverage
+::endgroup::"""
+    output = capsys.readouterr()
+    assert output.out.strip() == expected

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -39,6 +39,7 @@ def test_config__from_environ__ok():
             "MINIMUM_ORANGE": "50.8",
             "MERGE_COVERAGE_FILES": "true",
             "ANNOTATE_MISSING_LINES": "false",
+            "ANNOTATION_TYPE": "error",
             "VERBOSE": "false",
             "FORCE_WORKFLOW_RUN": "false",
         }
@@ -58,6 +59,7 @@ def test_config__from_environ__ok():
         MINIMUM_ORANGE=50.8,
         MERGE_COVERAGE_FILES=True,
         ANNOTATE_MISSING_LINES=False,
+        ANNOTATION_TYPE="error",
         VERBOSE=False,
         FORCE_WORKFLOW_RUN=False,
     )
@@ -102,6 +104,11 @@ def test_config__GITHUB_PR_NUMBER(config, github_ref, github_pr_number):
 def test_config__from_environ__error():
     with pytest.raises(ValueError):
         settings.Config.from_environ({"COMMENT_FILENAME": "/a"})
+
+
+def test_config__invalid_annotation_type():
+    with pytest.raises(settings.InvalidAnnotationType):
+        settings.Config.from_environ({"ANNOTATION_TYPE": "foo"})
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -38,6 +38,7 @@ def test_config__from_environ__ok():
             "MINIMUM_GREEN": "90",
             "MINIMUM_ORANGE": "50.8",
             "MERGE_COVERAGE_FILES": "true",
+            "ANNOTATE_MISSING_LINES": "false",
             "VERBOSE": "false",
             "FORCE_WORKFLOW_RUN": "false",
         }
@@ -56,6 +57,7 @@ def test_config__from_environ__ok():
         MINIMUM_GREEN=90.0,
         MINIMUM_ORANGE=50.8,
         MERGE_COVERAGE_FILES=True,
+        ANNOTATE_MISSING_LINES=False,
         VERBOSE=False,
         FORCE_WORKFLOW_RUN=False,
     )


### PR DESCRIPTION
This PR extends the action with a setting that makes it possible that all not covered lines can be [annotated](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-warning-message) in PR mode.

![2](https://user-images.githubusercontent.com/81773954/199728215-11073054-551a-4ec3-9a7f-6d6db03727be.png)
![1](https://user-images.githubusercontent.com/81773954/199728205-eb95c0d4-b75f-44a1-a19e-83af256728c5.png)
