### PR TITLE
Updated upload and download artifact actions from v2 to v3 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ jobs:
           # directly or through PYTEST_ADD_OPTS.
 
       - name: Store coverage file
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: .coverage.${{ matrix.python_version }}
@@ -190,7 +190,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3
         id: download
         with:
           name: 'coverage'
@@ -203,7 +203,7 @@ jobs:
           MERGE_COVERAGE_FILES: true
 
       - name: Store Pull Request comment to be posted
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         with:
           name: python-coverage-comment-action


### PR DESCRIPTION
This pull request updates the upload and download artifact actions mentioned in the `README.md` file from `v2` to `v3`.

The `v2` versions of these actions use NodeJS 12.0 which has been deprecated and creates warnings when used in workflows.