### PR TITLE
Add possibility for custom suffix for e2e test repos

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,5 @@ testpaths =
 
 filterwarnings =
     error
+markers=
+    repo_suffix: Allows to use an additional suffix for the e2e test repo.

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -210,12 +210,14 @@ def git_repo(cd, git, action_ref):
 
 
 @pytest.fixture
-def repo_name():
-    # TODO: should this depend on request.node.name ?
+def repo_name(request):
     name = "python-coverage-comment-action-end-to-end"
     if suffix := os.getenv("COVERAGE_COMMENT_E2E_REPO_SUFFIX"):
         suffix = re.sub(r"[^A-Za-z0-9_.-]", "-", suffix)
         name += f"-{suffix}"
+    mark = request.node.get_closest_marker("repo_suffix")
+    if mark is not None:
+        name = f"{name}-{'-'.join(mark.args)}"
     return name
 
 

--- a/tests/end_to_end/test_all.py
+++ b/tests/end_to_end/test_all.py
@@ -1,8 +1,10 @@
 import base64
 
 import httpx
+import pytest
 
 
+@pytest.mark.repo_suffix("public")
 def test_public_repo(
     gh_create_repo,
     wait_for_run_to_start,
@@ -165,6 +167,7 @@ def test_public_repo(
     assert ":arrow_up:" in ext_comment
 
 
+@pytest.mark.repo_suffix("private")
 def test_private_repo(
     gh_create_repo,
     wait_for_run_to_start,


### PR DESCRIPTION
This PR makes it possible to add a suffix to the e2e test repo with the `repo_suffix` mark. This way the private and the public repo can be named differently.