### PR TITLE
Improve Logging: use GHA workflow commands

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ github.token }}
           ANNOTATE_MISSING_LINES: true
-          VERBOSE: "true"
 
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v3

--- a/README.md
+++ b/README.md
@@ -264,9 +264,6 @@ jobs:
     # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message
     ANNOTATION_TYPE: warning
 
-    # If true, produces more output. Useful for debugging.
-    VERBOSE: false
-
     # Name of the artifact in which the body of the comment to post on the PR is stored.
     # You typically don't have to change this unless you're already using this name for something else.
     COMMENT_ARTIFACT_NAME: python-coverage-comment-action
@@ -281,6 +278,9 @@ jobs:
     # Name of the branch in which coverage data will be stored on the repository.
     # Please make sure that this branch is not protected.
     COVERAGE_DATA_BRANCH: python-coverage-comment-action-data
+
+    # Deprecated, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
+    VERBOSE: false
 ```
 
 ## Overriding the template

--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,7 @@ inputs:
     default: warning
   VERBOSE:
     description: >
-      If true, produces more output. Useful for debugging.
+      Deprecated, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
     default: false
 outputs:
   COMMENT_FILE_WRITTEN:

--- a/coverage_comment/github.py
+++ b/coverage_comment/github.py
@@ -173,11 +173,19 @@ def escape_data(s: str) -> str:
     return s.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
 
-def send_workflow_command(command: str, command_value: str, **kwargs: str) -> None:
+def get_workflow_command(command: str, command_value: str, **kwargs: str) -> str:
+    """
+    Returns a string that can be printed to send a workflow command
+    https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions
+    """
     values_listed = [f"{key}={escape_property(value)}" for key, value in kwargs.items()]
 
     context = f" {','.join(values_listed)}" if values_listed else ""
-    print(f"::{command}{context}::{escape_data(command_value)}")
+    return f"::{command}{context}::{escape_data(command_value)}"
+
+
+def send_workflow_command(command: str, command_value: str, **kwargs: str) -> None:
+    print(get_workflow_command(command=command, command_value=command_value, **kwargs))
 
 
 def create_missing_coverage_annotation(annotation_type: str, file: str, line: int):

--- a/coverage_comment/log_utils.py
+++ b/coverage_comment/log_utils.py
@@ -1,0 +1,19 @@
+import logging
+
+from coverage_comment import github
+
+LEVEL_MAPPING = {
+    50: "error",
+    40: "error",
+    30: "warning",
+    20: "notice",
+    10: "debug",
+}
+
+
+class GitHubFormatter(logging.Formatter):
+    def format(self, record):
+        log = super().format(record)
+        level = LEVEL_MAPPING[record.levelno]
+
+        return github.get_workflow_command(command=level, command_value=log)

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -12,6 +12,7 @@ from coverage_comment import (
     github,
     github_client,
     log,
+    log_utils,
     settings,
     storage,
     subprocess,
@@ -21,6 +22,7 @@ from coverage_comment import (
 
 def main():
     logging.basicConfig(level="INFO")
+    logging.getLogger().handlers[0].formatter = log_utils.GitHubFormatter()
 
     log.info("Starting action")
     config = settings.Config.from_environ(environ=os.environ)

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -21,30 +21,37 @@ from coverage_comment import (
 
 
 def main():
-    logging.basicConfig(level="DEBUG")
-    logging.getLogger().handlers[0].formatter = log_utils.GitHubFormatter()
+    try:
+        logging.basicConfig(level="DEBUG")
+        logging.getLogger().handlers[0].formatter = log_utils.GitHubFormatter()
 
-    log.info("Starting action")
-    config = settings.Config.from_environ(environ=os.environ)
+        log.info("Starting action")
+        config = settings.Config.from_environ(environ=os.environ)
 
-    github_session = httpx.Client(
-        base_url="https://api.github.com",
-        follow_redirects=True,
-        headers={"Authorization": f"token {config.GITHUB_TOKEN}"},
-    )
-    http_session = httpx.Client()
-    git = subprocess.Git()
-    storage.fix_ownership_issues(git=git)
+        github_session = httpx.Client(
+            base_url="https://api.github.com",
+            follow_redirects=True,
+            headers={"Authorization": f"token {config.GITHUB_TOKEN}"},
+        )
+        http_session = httpx.Client()
+        git = subprocess.Git()
+        storage.fix_ownership_issues(git=git)
 
-    exit_code = action(
-        config=config,
-        github_session=github_session,
-        http_session=http_session,
-        git=git,
-    )
+        exit_code = action(
+            config=config,
+            github_session=github_session,
+            http_session=http_session,
+            git=git,
+        )
 
-    log.info("Ending action")
-    sys.exit(exit_code)
+        log.info("Ending action")
+        sys.exit(exit_code)
+
+    except Exception:
+        log.exception(
+            "Critical error. Please look for open issues or open one in https://github.com/py-cov-action/python-coverage-comment-action/"
+        )
+        sys.exit(1)
 
 
 def action(

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -21,14 +21,11 @@ from coverage_comment import (
 
 
 def main():
-    logging.basicConfig(level="INFO")
+    logging.basicConfig(level="DEBUG")
     logging.getLogger().handlers[0].formatter = log_utils.GitHubFormatter()
 
     log.info("Starting action")
     config = settings.Config.from_environ(environ=os.environ)
-    if config.VERBOSE:
-        logging.getLogger().setLevel("DEBUG")
-        log.debug(f"Settings: {config}")
 
     github_session = httpx.Client(
         base_url="https://api.github.com",

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -4,6 +4,8 @@ import inspect
 import pathlib
 from typing import Any
 
+from coverage_comment import log
+
 
 class MissingEnvironmentVariable(Exception):
     pass
@@ -81,7 +83,11 @@ class Config:
 
     @classmethod
     def clean_verbose(cls, value: str) -> bool:
-        return str_to_bool(value)
+        if str_to_bool(value):
+            log.info(
+                "VERBOSE setting is deprecated. For increased debug output, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging"
+            )
+        return False
 
     @classmethod
     def clean_force_workflow_run(cls, value: str) -> bool:

--- a/coverage_comment/storage.py
+++ b/coverage_comment/storage.py
@@ -44,7 +44,7 @@ def initialize_branch(
 
 
 @contextlib.contextmanager
-def on_coverage_branch(git: subprocess.Git, branch: str):
+def checked_out_branch(git: subprocess.Git, branch: str):
     try:
         current_checkout = git.branch("--show-current").strip()
     except subprocess.SubProcessError:
@@ -89,7 +89,7 @@ def upload_files(
     initial_file : files.FileWithPath
         In case the branch didn't exist, initialize it with this initial file.
     """
-    with on_coverage_branch(git=git, branch=branch) as branch_exists:
+    with checked_out_branch(git=git, branch=branch) as branch_exists:
         if not branch_exists:
             initialize_branch(
                 git=git,

--- a/dev-env
+++ b/dev-env
@@ -131,7 +131,6 @@ function run(){
 event push
 ref branch
 run $(gh run list --limit 1 --json databaseId --jq='.[].databaseId')
-export VERBOSE=true
 
 function help(){
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ def base_config():
             "GITHUB_REPOSITORY": "py-cov-action/foobar",
             # Action settings
             "MERGE_COVERAGE_FILES": True,
-            "VERBOSE": False,
         }
         return settings.Config(**(defaults | kwargs))
 

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -252,6 +252,15 @@ def gh_create_repo(is_failed, gh_delete_repo, gh_me, git_repo, repo_name):
             f"--source={git_repo}",
             *args,
         )
+        # Someday, we may be able to change that to a variable instead of a secret
+        # https://github.com/cli/cli/pull/6928
+        gh_me(
+            "secret",
+            "set",
+            "--app=actions",
+            "ACTIONS_STEP_DEBUG",
+            "--body=true",
+        )
         return git_repo
 
     yield f

--- a/tests/end_to_end/repo/.github/workflows/ci.yml
+++ b/tests/end_to_end/repo/.github/workflows/ci.yml
@@ -36,7 +36,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           ANNOTATE_MISSING_LINES: true
           ANNOTATION_TYPE: notice
-          VERBOSE: "true"
 
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v3

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -291,18 +291,26 @@ def test_set_output(output_file):
     assert output_file.read_text() == "foo=true\n"
 
 
+def test_get_workflow_command():
+    output = github.get_workflow_command(
+        command="foo", command_value="bar", file="main.py", line="1", title="someTitle"
+    )
+
+    assert output == "::foo file=main.py,line=1,title=someTitle::bar"
+
+
+def test_get_workflow_command_no_kwargs():
+    output = github.get_workflow_command(command="group", command_value="title")
+
+    assert output == "::group::title"
+
+
 def test_send_workflow_command(capsys):
     github.send_workflow_command(
         command="foo", command_value="bar", file="main.py", line="1", title="someTitle"
     )
     output = capsys.readouterr()
     assert output.out.strip() == "::foo file=main.py,line=1,title=someTitle::bar"
-
-
-def test_send_workflow_command_no_kwargs(capsys):
-    github.send_workflow_command(command="group", command_value="title")
-    output = capsys.readouterr()
-    assert output.out.strip() == "::group::title"
 
 
 def test_create_missing_coverage_annotation(capsys):

--- a/tests/unit/test_log_utils.py
+++ b/tests/unit/test_log_utils.py
@@ -1,0 +1,50 @@
+import logging
+import re
+
+from coverage_comment import log_utils
+
+
+def test_level_mapping__all_supported():
+    # TODO Python 3.11: replace logging._levelToName with
+    # logging.getLevelNamesMapping()
+    ignored = {
+        logging.getLevelName("NOTSET"),
+        logging.getLevelName("TRACE"),
+    }
+    assert set(log_utils.LEVEL_MAPPING) == set(logging._levelToName) - ignored
+
+
+def test__github_formatter():
+    logs = []
+
+    class TestHandler(logging.Handler):
+        def emit(self, record):
+            logs.append(self.format(record))
+
+    logger = logging.Logger("test", level="DEBUG")
+    handler = TestHandler()
+    handler.setFormatter(log_utils.GitHubFormatter())
+    logger.addHandler(handler)
+
+    logger.debug("a debug message")
+    logger.info("a notice message")
+    logger.warning("a warning message")
+    logger.error("an error message")
+    logger.critical("an error message")
+    try:
+        0 / 0
+    except Exception:
+        logger.exception("an exception")
+
+    logs = "\n".join(logs)
+    logs = re.sub(r"""File ".+", line \d+""", """File "foo.py", line 42""", logs)
+
+    expected = """
+::debug::a debug message
+::notice::a notice message
+::warning::a warning message
+::error::an error message
+::error::an error message
+::error::an exception%0ATraceback (most recent call last):%0A  File "foo.py", line 42, in test__github_formatter%0A    0 / 0%0AZeroDivisionError: division by zero""".strip()
+
+    assert logs == expected

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -58,3 +58,26 @@ def test_main(mocker, get_logs):
 
     assert get_logs("INFO", "Starting action")
     assert get_logs("INFO", "Ending action")
+
+
+def test_main__exception(mocker, get_logs):
+    # This test simulates an exception in the main part of the action. This should be catched and logged.
+    exit = mocker.patch("sys.exit")
+    mocker.patch(
+        "coverage_comment.main.action", side_effect=Exception("Mocked exception")
+    )
+
+    os.environ.update(
+        {
+            "GITHUB_REPOSITORY": "foo/bar",
+            "GITHUB_PR_RUN_ID": "",
+            "GITHUB_REF": "ref",
+            "GITHUB_TOKEN": "token",
+            "GITHUB_BASE_REF": "",
+            "GITHUB_EVENT_NAME": "push",
+        }
+    )
+    main.main()
+    exit.assert_called_with(1)
+
+    assert get_logs("ERROR", "Critical error")

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,4 +1,3 @@
-import logging
 import os
 
 import httpx
@@ -29,7 +28,7 @@ def test_post_comment__no_run_id(workflow_run_config, get_logs):
 
 
 def test_main(mocker, get_logs):
-    # This test is a mock frienzy. The idea is that all the things that are hard
+    # This test is a mock festival. The idea is that all the things that are hard
     # to simulate without mocks have been pushed up the stack up to this function
     # so this is THE place where we have no choice but to mock.
     # We could also accept not to test this function but if we've come this
@@ -59,30 +58,3 @@ def test_main(mocker, get_logs):
 
     assert get_logs("INFO", "Starting action")
     assert get_logs("INFO", "Ending action")
-
-
-def test_main__verbose(mocker, get_logs, caplog):
-    # This test is a mock frienzy. The idea is that all the things that are hard
-    # to simulate without mocks have been pushed up the stack up to this function
-    # so this is THE place where we have no choice but to mock.
-    # We could also accept not to test this function but if we've come this
-    # far and have 98% coverage, we can as well have 100%.
-
-    mocker.patch("sys.exit")
-    mocker.patch("coverage_comment.main.action")
-
-    os.environ.update(
-        {
-            "GITHUB_REPOSITORY": "foo/bar",
-            "GITHUB_PR_RUN_ID": "",
-            "GITHUB_REF": "ref",
-            "GITHUB_TOKEN": "token",
-            "GITHUB_BASE_REF": "",
-            "GITHUB_EVENT_NAME": "push",
-            "VERBOSE": "true",
-        }
-    )
-    main.main()
-
-    assert get_logs("DEBUG", "Settings: Config(")
-    assert logging.getLevelName(logging.getLogger().level) == "DEBUG"

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -81,7 +81,6 @@ def config():
         "MINIMUM_GREEN": decimal.Decimal("90"),
         "MINIMUM_ORANGE": decimal.Decimal("50.8"),
         "MERGE_COVERAGE_FILES": True,
-        "VERBOSE": False,
     }
 
     def _(**kwargs):

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -66,6 +66,29 @@ def test_config__from_environ__ok():
     )
 
 
+def test_config__verbose_deprecated(get_logs):
+    assert settings.Config.from_environ(
+        {
+            "GITHUB_BASE_REF": "master",
+            "GITHUB_TOKEN": "foo",
+            "GITHUB_REPOSITORY": "owner/repo",
+            "GITHUB_REF": "master",
+            "GITHUB_EVENT_NAME": "pull",
+            "GITHUB_PR_RUN_ID": "123",
+            "VERBOSE": "true",
+        }
+    ) == settings.Config(
+        GITHUB_BASE_REF="master",
+        GITHUB_TOKEN="foo",
+        GITHUB_REPOSITORY="owner/repo",
+        GITHUB_REF="master",
+        GITHUB_EVENT_NAME="pull",
+        GITHUB_PR_RUN_ID=123,
+        VERBOSE=False,
+    )
+    assert get_logs("INFO", "VERBOSE setting is deprecated")
+
+
 @pytest.fixture
 def config():
     defaults = {

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -30,33 +30,33 @@ def test_initialize_branch(git, tmp_path):
     assert readme_path.read_text() == "bar"
 
 
-def test_on_coverage_branch(git):
+def test_checked_out_branch(git):
     git.register("git branch --show-current")(stdout="bar")
     git.register("git fetch")()
     git.register("git checkout foo")()
 
-    with storage.on_coverage_branch(git=git, branch="foo") as exists:
+    with storage.checked_out_branch(git=git, branch="foo") as exists:
         assert exists is True
         git.register("git checkout bar")()
 
 
-def test_on_coverage_branch__detached_head(git):
+def test_checked_out_branch__detached_head(git):
     git.register("git branch --show-current")(exit_code=1)
     git.register("git rev-parse --short HEAD")(stdout="123abc")
     git.register("git fetch")()
     git.register("git checkout foo")()
 
-    with storage.on_coverage_branch(git=git, branch="foo") as exists:
+    with storage.checked_out_branch(git=git, branch="foo") as exists:
         assert exists is True
         git.register("git checkout 123abc")()
 
 
-def test_on_coverage_branch__branch_doesnt_exist(git):
+def test_checked_out_branch__branch_doesnt_exist(git):
     git.register("git branch --show-current")(stdout="bar")
     git.register("git fetch")()
     git.register("git checkout foo")(exit_code=1)
 
-    with storage.on_coverage_branch(git=git, branch="foo") as exists:
+    with storage.checked_out_branch(git=git, branch="foo") as exists:
         assert exists is False
         git.register("git checkout bar")()
 
@@ -77,7 +77,7 @@ def test_upload_files(git, in_tmp_path, branch_exists, has_diff):
         files.FileWithPath(path=pathlib.Path("c.txt"), contents=None),
     ]
 
-    # on_coverage_branch
+    # checked_out_branch
     git.register("git branch --show-current")(stdout="bar")
     git.register("git fetch")()
     git.register("git checkout foo")(exit_code=0 if branch_exists else 1)
@@ -122,7 +122,7 @@ def test_upload_files(git, in_tmp_path, branch_exists, has_diff):
         )()
         git.register("git push origin foo")()
 
-    # __exit__ of on_coverage_branch
+    # __exit__ of checked_out_branch
     git.register("git checkout bar")()
 
     storage.upload_files(


### PR DESCRIPTION
Multiple things appear in this PR, please feel free to request if you're more comfortable if I split it into multiple PRs

- First, I split the method for generating workflow command strings so that we decouple generating the string and printing it. 
- Rename on_coverage_branch > checked_out_branch: kind of unrelated change. I had originally more on there but I decided not to keep it. This one is an isolated change and it annoys me every time I see this function name
- Add a GitHub formatter that formats logs the GitHub way: that's the main thing of the PR: making it so that `logger.error`displays a proper error in the GHA output.
- Deprecate VERBOSE setting: The correct way to add logging to a GitHub Action should be to do it the GitHub way (I've added `ACTIONS_STEP_DEBUG=true` in this repo btw)
- If exception bubbles up to the top, log it properly: While we're at it, if the action fails with an exception, at least make it a pretty one.
<img width="705" alt="Capture d’écran 2023-02-05 à 18 16 10" src="https://user-images.githubusercontent.com/1457576/216834026-6db3063d-b34b-4cbe-8c52-4710ca96f86c.png">