### PR TITLE
Fix typo (replace `/n` with `\n`)

### DIFF
--- a/coverage_comment/subprocess.py
+++ b/coverage_comment/subprocess.py
@@ -22,7 +22,7 @@ def run(*args, **kwargs) -> str:
             **kwargs,
         ).stdout
     except subprocess.CalledProcessError as exc:
-        raise SubProcessError("/n".join([exc.stdout, exc.stderr])) from exc
+        raise SubProcessError("\n".join([exc.stdout, exc.stderr])) from exc
 
 
 class Git:


### PR DESCRIPTION
Fix typo in `SubProcessError` error message (in `subprocess.py`).