### PR TITLE
Add comment regarding permissions to exception message

### DIFF
--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -48,7 +48,7 @@ def main():
 
     except Exception:
         log.exception(
-            "Critical error. Please look for open issues or open one in https://github.com/py-cov-action/python-coverage-comment-action/"
+            "Critical error. This error possibly occurred because the permissions of the workflow are set incorrectly. You can see the correct setting of permissions here: https://github.com/py-cov-action/python-coverage-comment-action#basic-usage\nOtherwise please look for open issues or open one in https://github.com/py-cov-action/python-coverage-comment-action/"
         )
         sys.exit(1)
 


### PR DESCRIPTION
Due to the fact that the default settings regarding permissions only differ in newly created repos, the workflow may not work in forks even though it works in the original repo because the permissions are set differently in the fork. In this case, the current error message is relatively unhelpful. This PR is intended to improve that.