### PR TITLE
Add concurrency to e2e-repo workflow

### DIFF
--- a/tests/end_to_end/repo/.github/workflows/ci.yml
+++ b/tests/end_to_end/repo/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'main'
 
+concurrency:
+  group: CI
+
 jobs:
   test:
     name: Run tests & display/prepare coverage


### PR DESCRIPTION
This PR adds concurrency to the CI workflow in the e2e-test repo. The reason for this is that there are sometimes problems because the action for the initial commit is started multiple times. With concurrency, the workflow should at least no longer run in parallel and thus not cause so many problems.