### PR TITLE
feat: marker as argument

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 name: Python Coverage Comment
 branding:
-  icon: 'umbrella'
-  color: 'purple'
+  icon: "umbrella"
+  color: "purple"
 description: >
   Publish diff coverage report as PR comment, and create a coverage badge
   to display on the readme.
@@ -69,6 +69,12 @@ inputs:
     description: >
       Deprecated, see https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/enabling-debug-logging
     default: false
+  MARKER:
+    description: >
+      Identifier to find the comment in the PR. This will be used to update
+      the comment instead of creating a new one.
+    default: "<!-- This comment was produced by coverage-comment-action -->"
+    required: false
 outputs:
   COMMENT_FILE_WRITTEN:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -96,3 +96,4 @@ runs:
     ANNOTATE_MISSING_LINES: ${{ inputs.ANNOTATE_MISSING_LINES }}
     ANNOTATION_TYPE: ${{ inputs.ANNOTATION_TYPE }}
     VERBOSE: ${{ inputs.VERBOSE }}
+    MARKER: ${{ inputs.MARKER }}

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -130,6 +130,7 @@ def generate_comment(
             previous_coverage_rate=previous_coverage,
             base_template=template.read_template_file("comment.md.j2"),
             custom_template=config.COMMENT_TEMPLATE,
+            marker=config.MARKER,
         )
     except template.MissingMarker:
         log.error(
@@ -159,7 +160,7 @@ def generate_comment(
             repository=config.GITHUB_REPOSITORY,
             pr_number=config.GITHUB_PR_NUMBER,
             contents=comment,
-            marker=template.MARKER,
+            marker=config.MARKER,
         )
     except github.CannotPostComment:
         log.debug("Exception when posting comment", exc_info=True)
@@ -232,7 +233,7 @@ def post_comment(config: settings.Config, github_session: httpx.Client) -> int:
         repository=config.GITHUB_REPOSITORY,
         pr_number=pr_number,
         contents=comment,
-        marker=template.MARKER,
+        marker=config.MARKER,
     )
     log.info("Comment posted in PR")
 

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -51,6 +51,7 @@ class Config:
     VERBOSE: bool = False
     # Only for debugging, not exposed in the action:
     FORCE_WORKFLOW_RUN: bool = False
+    MARKER: str = "<!-- This comment was produced by python-coverage-comment-action -->"
 
     # Clean methods
     @classmethod

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -51,7 +51,7 @@ class Config:
     VERBOSE: bool = False
     # Only for debugging, not exposed in the action:
     FORCE_WORKFLOW_RUN: bool = False
-    MARKER: str = "<!-- This comment was produced by python-coverage-comment-action -->"
+    MARKER: str | None = None
 
     # Clean methods
     @classmethod

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -111,6 +111,9 @@ class Config:
 
     @classmethod
     def from_environ(cls, environ: dict[str, str]) -> "Config":
+        for key, value in environ.items():
+            print(f"{key}={value}")
+
         possible_variables = [e for e in inspect.signature(cls).parameters]
         config: dict[str, Any] = {
             k: v for k, v in environ.items() if k in possible_variables

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -111,9 +111,6 @@ class Config:
 
     @classmethod
     def from_environ(cls, environ: dict[str, str]) -> "Config":
-        for key, value in environ.items():
-            print(f"{key}={value}")
-
         possible_variables = [e for e in inspect.signature(cls).parameters]
         config: dict[str, Any] = {
             k: v for k, v in environ.items() if k in possible_variables

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -42,6 +42,7 @@ class Config:
     COVERAGE_DATA_BRANCH: str = "python-coverage-comment-action-data"
     COMMENT_ARTIFACT_NAME: str = "python-coverage-comment-action"
     COMMENT_FILENAME: pathlib.Path = pathlib.Path("python-coverage-comment-action.txt")
+    MARKER: str = "<!-- This comment was produced by python-coverage-comment-action -->"
     GITHUB_OUTPUT: pathlib.Path | None = None
     MINIMUM_GREEN: decimal.Decimal = decimal.Decimal("100")
     MINIMUM_ORANGE: decimal.Decimal = decimal.Decimal("70")
@@ -51,7 +52,6 @@ class Config:
     VERBOSE: bool = False
     # Only for debugging, not exposed in the action:
     FORCE_WORKFLOW_RUN: bool = False
-    MARKER: str | None = None
 
     # Clean methods
     @classmethod

--- a/coverage_comment/template.py
+++ b/coverage_comment/template.py
@@ -7,8 +7,6 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from coverage_comment import coverage as coverage_module
 
-MARKER = """<!-- This comment was produced by python-coverage-comment-action -->"""
-
 
 def uptodate():
     return True
@@ -45,6 +43,7 @@ def get_comment_markdown(
     previous_coverage_rate: decimal.Decimal | None,
     base_template: str,
     custom_template: str | None = None,
+    marker: str = "<!-- This comment was produced by python-coverage-comment-action -->",
 ):
     loader = CommentLoader(base_template=base_template, custom_template=custom_template)
     env = SandboxedEnvironment(loader=loader)
@@ -55,12 +54,12 @@ def get_comment_markdown(
             previous_coverage_rate=previous_coverage_rate,
             coverage=coverage,
             diff_coverage=diff_coverage,
-            marker=MARKER,
+            marker=marker,
         )
     except jinja2.exceptions.TemplateError as exc:
         raise TemplateError from exc
 
-    if MARKER not in comment:
+    if marker not in comment:
         raise MissingMarker()
 
     return comment

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -43,6 +43,7 @@ def test_config__from_environ__ok():
             "ANNOTATION_TYPE": "error",
             "VERBOSE": "false",
             "FORCE_WORKFLOW_RUN": "false",
+            "MARKER": "<!-- foo -->",
         }
     ) == settings.Config(
         GITHUB_BASE_REF="master",
@@ -63,6 +64,7 @@ def test_config__from_environ__ok():
         ANNOTATION_TYPE="error",
         VERBOSE=False,
         FORCE_WORKFLOW_RUN=False,
+        MARKER="<!-- foo -->",
     )
 
 

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -22,6 +22,7 @@ def test_get_comment_markdown(coverage_obj, diff_coverage_obj):
             custom_template="""{% extends "base" %}
         {% block foo %}bar{% endblock foo %}
         """,
+            marker="<!-- This a fake marker-->",
         )
         .strip()
         .split(maxsplit=4)
@@ -32,7 +33,7 @@ def test_get_comment_markdown(coverage_obj, diff_coverage_obj):
         "75%",
         "80%",
         "bar",
-        "<!-- This comment was produced by python-coverage-comment-action -->",
+        "<!-- This a fake marker-->",
     ]
 
     assert result == expected


### PR DESCRIPTION
- added the "marker" argument to enable multiple comments for multiple services in a single repository 
- adjusted tests for a custom marker
<img width="926" alt="image" src="https://github.com/py-cov-action/python-coverage-comment-action/assets/37148029/38ec5deb-3ad3-4829-bda1-ad40e0865199">
