### PR TITLE
Add job summaries for PR and push mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ of coverage rate attributed to this PR, as well as the rate of coverage
 for lines that this PR introduces. There's also a small analysis for each
 file in a collapsed block.
 
+This comment will also be output as a [job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary).
+
 See [an example](https://github.com/py-cov-action/python-coverage-comment-action-v3-example/pull/2#issuecomment-1244431724).
 
 ### Default branch mode
@@ -40,7 +42,7 @@ These files include:
   repository is public to customize the look of your badge
 - Another `json` file used internally by the action to report on coverage
   evolution (does a PR make the coverage go up or down?)
-- A short file-by-file coverage report embedded directy into the branch's README
+- A short file-by-file coverage report embedded directy into the branch's README. An excerpt from this is also output directly as a [job summary](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary).
 - The full HTML coverage report and links to make this report browsable
 
 See [an example](https://github.com/py-cov-action/python-coverage-comment-action-v3-example)

--- a/coverage_comment/github.py
+++ b/coverage_comment/github.py
@@ -197,10 +197,10 @@ def create_missing_coverage_annotation(annotation_type: str, file: str, line: in
     )
 
 
-def append_to_environment_file(content: str, filepath: pathlib.Path):
+def append_to_file(content: str, filepath: pathlib.Path):
     with filepath.open(mode="a") as file:
         file.write(content)
 
 
 def add_job_summary(content: str, github_step_summary: pathlib.Path):
-    append_to_environment_file(content=content, filepath=github_step_summary)
+    append_to_file(content=content, filepath=github_step_summary)

--- a/coverage_comment/github.py
+++ b/coverage_comment/github.py
@@ -195,3 +195,12 @@ def create_missing_coverage_annotation(annotation_type: str, file: str, line: in
         file=file,
         line=str(line),
     )
+
+
+def append_to_environment_file(content: str, filepath: pathlib.Path):
+    with filepath.open(mode="a") as file:
+        file.write(content)
+
+
+def add_job_summary(content: str, github_step_summary: pathlib.Path):
+    append_to_environment_file(content=content, filepath=github_step_summary)

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -279,7 +279,7 @@ def save_coverage_data_files(
     markdown_report = coverage_module.generate_coverage_markdown()
 
     github.add_job_summary(
-        content=f"## Coverage report\n{markdown_report}",
+        content=f"## Coverage report\n\n{markdown_report}",
         github_step_summary=config.GITHUB_STEP_SUMMARY,
     )
 

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -149,6 +149,11 @@ def generate_comment(
         return 1
 
     assert config.GITHUB_PR_NUMBER
+
+    github.add_job_summary(
+        content=comment, github_step_summary=config.GITHUB_STEP_SUMMARY
+    )
+
     try:
         if config.FORCE_WORKFLOW_RUN:
             raise github.CannotPostComment
@@ -272,6 +277,11 @@ def save_coverage_data_files(
         operations.append(files.get_coverage_html_files())
 
     markdown_report = coverage_module.generate_coverage_markdown()
+
+    github.add_job_summary(
+        content=f"## Coverage report\n{markdown_report}",
+        github_step_summary=config.GITHUB_STEP_SUMMARY,
+    )
 
     url_getter = functools.partial(
         storage.get_raw_file_url,

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -38,6 +38,7 @@ class Config:
     GITHUB_REF: str
     GITHUB_EVENT_NAME: str
     GITHUB_PR_RUN_ID: int | None
+    GITHUB_STEP_SUMMARY: pathlib.Path
     COMMENT_TEMPLATE: str | None = None
     COVERAGE_DATA_BRANCH: str = "python-coverage-comment-action-data"
     COMMENT_ARTIFACT_NAME: str = "python-coverage-comment-action"
@@ -64,6 +65,10 @@ class Config:
     @classmethod
     def clean_github_pr_run_id(cls, value: str) -> int | None:
         return int(value) if value else None
+
+    @classmethod
+    def clean_github_step_summary(cls, value: str) -> pathlib.Path:
+        return pathlib.Path(value)
 
     @classmethod
     def clean_merge_coverage_files(cls, value: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import decimal
 import functools
 import io
 import os
+import pathlib
 import zipfile
 
 import httpx
@@ -20,6 +21,7 @@ def base_config():
             "GITHUB_TOKEN": "foo",
             "GITHUB_PR_RUN_ID": 123,
             "GITHUB_REPOSITORY": "py-cov-action/foobar",
+            "GITHUB_STEP_SUMMARY": pathlib.Path("step_summary"),
             # Action settings
             "MERGE_COVERAGE_FILES": True,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -458,6 +458,14 @@ def output_file(tmp_path):
     return file
 
 
+@pytest.fixture
+def summary_file(tmp_path):
+    file = tmp_path / "step_summary.txt"
+    file.touch()
+
+    return file
+
+
 _is_failed = []
 
 

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -336,7 +336,11 @@ def test_create_missing_coverage_annotation__annotation_type(capsys):
 
 def test_add_job_summary(summary_file):
     github.add_job_summary(
-        content="[job summary content]", github_step_summary=summary_file
+        content="[job summary part 1]\n", github_step_summary=summary_file
     )
+    assert summary_file.read_text() == "[job summary part 1]\n"
 
-    assert summary_file.read_text() == "[job summary content]"
+    github.add_job_summary(
+        content="[job summary part 2]", github_step_summary=summary_file
+    )
+    assert summary_file.read_text() == "[job summary part 1]\n[job summary part 2]"

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -332,3 +332,11 @@ def test_create_missing_coverage_annotation__annotation_type(capsys):
     assert (
         output.out.strip() == "::error file=test.py,line=42::This line has no coverage"
     )
+
+
+def test_add_job_summary(summary_file):
+    github.add_job_summary(
+        content="[job summary content]", github_step_summary=summary_file
+    )
+
+    assert summary_file.read_text() == "[job summary content]"

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -366,10 +366,13 @@ You can use the following URLs to display your badge:
 See more details and ready-to-copy-paste-markdown at:
     https://github.com/py-cov-action/foobar/tree/python-coverage-comment-action-data"""
     assert log == expected
-    assert "## Coverage report" in summary_file.read_text()
-    assert "Name" in summary_file.read_text()
-    assert "Stmts" in summary_file.read_text()
-    assert "Missing" in summary_file.read_text()
+
+    summary_content = summary_file.read_text()
+
+    assert "## Coverage report" in summary_content
+    assert "Name" in summary_content
+    assert "Stmts" in summary_content
+    assert "Missing" in summary_content
 
 
 def test_action__push__default_branch__private(

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -45,6 +45,7 @@ def test_main(mocker, get_logs):
             "GITHUB_TOKEN": "token",
             "GITHUB_BASE_REF": "",
             "GITHUB_EVENT_NAME": "push",
+            "GITHUB_STEP_SUMMARY": "step_summary",
         }
     )
     main.main()
@@ -75,6 +76,7 @@ def test_main__exception(mocker, get_logs):
             "GITHUB_TOKEN": "token",
             "GITHUB_BASE_REF": "",
             "GITHUB_EVENT_NAME": "push",
+            "GITHUB_STEP_SUMMARY": "step_summary",
         }
     )
     main.main()

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -32,6 +32,7 @@ def test_config__from_environ__ok():
             "GITHUB_OUTPUT": "foo.txt",
             "GITHUB_EVENT_NAME": "pull",
             "GITHUB_PR_RUN_ID": "123",
+            "GITHUB_STEP_SUMMARY": "step_summary",
             "COMMENT_ARTIFACT_NAME": "baz",
             "COMMENT_FILENAME": "qux",
             "COMMENT_TEMPLATE": "footemplate",
@@ -52,6 +53,7 @@ def test_config__from_environ__ok():
         GITHUB_OUTPUT=pathlib.Path("foo.txt"),
         GITHUB_EVENT_NAME="pull",
         GITHUB_PR_RUN_ID=123,
+        GITHUB_STEP_SUMMARY=pathlib.Path("step_summary"),
         COMMENT_ARTIFACT_NAME="baz",
         COMMENT_FILENAME=pathlib.Path("qux"),
         COMMENT_TEMPLATE="footemplate",
@@ -75,6 +77,7 @@ def test_config__verbose_deprecated(get_logs):
             "GITHUB_REF": "master",
             "GITHUB_EVENT_NAME": "pull",
             "GITHUB_PR_RUN_ID": "123",
+            "GITHUB_STEP_SUMMARY": "step_summary",
             "VERBOSE": "true",
         }
     ) == settings.Config(
@@ -84,6 +87,7 @@ def test_config__verbose_deprecated(get_logs):
         GITHUB_REF="master",
         GITHUB_EVENT_NAME="pull",
         GITHUB_PR_RUN_ID=123,
+        GITHUB_STEP_SUMMARY=pathlib.Path("step_summary"),
         VERBOSE=False,
     )
     assert get_logs("INFO", "VERBOSE setting is deprecated")
@@ -98,6 +102,7 @@ def config():
         "GITHUB_REF": "master",
         "GITHUB_EVENT_NAME": "pull",
         "GITHUB_PR_RUN_ID": 123,
+        "GITHUB_STEP_SUMMARY": pathlib.Path("step_summary"),
         "COMMENT_ARTIFACT_NAME": "baz",
         "COMMENT_FILENAME": pathlib.Path("qux"),
         "COVERAGE_DATA_BRANCH": "branchname",


### PR DESCRIPTION
Closes #187

The changes in this PR add [job summaries](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#adding-a-job-summary) as a functionality. This means that in PR mode the comment and in push mode the coverage table are also displayed as a job summary.
![1](https://github.com/py-cov-action/python-coverage-comment-action/assets/81773954/72c6c268-8830-4279-b07e-962264594a5a)
![2](https://github.com/py-cov-action/python-coverage-comment-action/assets/81773954/c06cc36a-71af-4b4a-902f-a1a66bac93fb)
