### PR TITLE
Create annotations based on diff-coverage, not full coverage

### DIFF
--- a/coverage_comment/annotations.py
+++ b/coverage_comment/annotations.py
@@ -4,15 +4,19 @@ from coverage_comment import github
 MISSING_LINES_GROUP_TITLE = "Annotations of lines with missing coverage"
 
 
-def create_pr_annotations(annotation_type: str, coverage: coverage_module.Coverage):
+def create_pr_annotations(
+    annotation_type: str, diff_coverage: coverage_module.DiffCoverage
+):
     github.send_workflow_command(
         command="group", command_value=MISSING_LINES_GROUP_TITLE
     )
 
-    for filename, file_coverage in coverage.files.items():
-        for missing_line in file_coverage.missing_lines:
+    for file_path, file_diff_coverage in diff_coverage.files.items():
+        for missing_line in file_diff_coverage.violation_lines:
             github.create_missing_coverage_annotation(
-                annotation_type=annotation_type, file=filename, line=missing_line
+                annotation_type=annotation_type,
+                file=file_path,
+                line=missing_line,
             )
 
     github.send_workflow_command(command="endgroup", command_value="")

--- a/coverage_comment/coverage.py
+++ b/coverage_comment/coverage.py
@@ -31,7 +31,7 @@ class CoverageInfo:
 
 @dataclasses.dataclass
 class FileCoverage:
-    path: str
+    path: pathlib.Path
     executed_lines: list[int]
     missing_lines: list[int]
     excluded_lines: list[int]
@@ -42,12 +42,12 @@ class FileCoverage:
 class Coverage:
     meta: CoverageMetadata
     info: CoverageInfo
-    files: dict[str, FileCoverage]
+    files: dict[pathlib.Path, FileCoverage]
 
 
 @dataclasses.dataclass
 class FileDiffCoverage:
-    path: str
+    path: pathlib.Path
     percent_covered: decimal.Decimal
     violation_lines: list[int]
 
@@ -146,8 +146,8 @@ def extract_info(data) -> Coverage:
             show_contexts=data["meta"]["show_contexts"],
         ),
         files={
-            path: FileCoverage(
-                path=path,
+            pathlib.Path(path): FileCoverage(
+                path=pathlib.Path(path),
                 excluded_lines=file_data["excluded_lines"],
                 executed_lines=file_data["executed_lines"],
                 missing_lines=file_data["missing_lines"],
@@ -235,8 +235,8 @@ def extract_diff_info(data) -> DiffCoverage:
         ),
         num_changed_lines=data["num_changed_lines"],
         files={
-            path: FileDiffCoverage(
-                path=path,
+            pathlib.Path(path): FileDiffCoverage(
+                path=pathlib.Path(path),
                 percent_covered=decimal.Decimal(str(file_data["percent_covered"]))
                 / decimal.Decimal("100"),
                 violation_lines=file_data["violation_lines"],

--- a/coverage_comment/github.py
+++ b/coverage_comment/github.py
@@ -192,11 +192,15 @@ def send_workflow_command(command: str, command_value: str, **kwargs: str) -> No
     )
 
 
-def create_missing_coverage_annotation(annotation_type: str, file: str, line: int):
+def create_missing_coverage_annotation(
+    annotation_type: str, file: pathlib.Path, line: int
+):
     send_workflow_command(
         command=annotation_type,
         command_value=MISSING_COVERAGE_MESSAGE,
-        file=file,
+        # This will produce \ paths when running on windows.
+        # GHA doc is unclear whether this is right or not.
+        file=str(file),
         line=str(line),
     )
 

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -73,15 +73,19 @@ def action(
 
     if event_name in {"pull_request", "push"}:
         coverage = coverage_module.get_coverage_info(merge=config.MERGE_COVERAGE_FILES)
+
         if event_name == "pull_request":
+            diff_coverage = coverage_module.get_diff_coverage_info(
+                base_ref=config.GITHUB_BASE_REF
+            )
             if config.ANNOTATE_MISSING_LINES:
                 annotations.create_pr_annotations(
-                    annotation_type=config.ANNOTATION_TYPE, coverage=coverage
+                    annotation_type=config.ANNOTATION_TYPE, diff_coverage=diff_coverage
                 )
-
             return generate_comment(
                 config=config,
                 coverage=coverage,
+                diff_coverage=diff_coverage,
                 github_session=github_session,
             )
         else:
@@ -105,15 +109,13 @@ def action(
 def generate_comment(
     config: settings.Config,
     coverage: coverage_module.Coverage,
+    diff_coverage: coverage_module.DiffCoverage,
     github_session: httpx.Client,
 ) -> int:
     log.info("Generating comment for PR")
 
     gh = github_client.GitHub(session=github_session)
 
-    diff_coverage = coverage_module.get_diff_coverage_info(
-        base_ref=config.GITHUB_BASE_REF
-    )
     previous_coverage_data_file = storage.get_datafile_contents(
         github=gh,
         repository=config.GITHUB_REPOSITORY,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -217,65 +217,6 @@ def coverage_obj_no_branch():
 
 
 @pytest.fixture
-def coverage_obj_many_missing_lines():
-    return coverage_module.Coverage(
-        meta=coverage_module.CoverageMetadata(
-            version="1.2.3",
-            timestamp=datetime.datetime(2000, 1, 1),
-            branch_coverage=True,
-            show_contexts=False,
-        ),
-        info=coverage_module.CoverageInfo(
-            covered_lines=7,
-            num_statements=10,
-            percent_covered=decimal.Decimal("0.8"),
-            missing_lines=12,
-            excluded_lines=0,
-            num_branches=2,
-            num_partial_branches=1,
-            covered_branches=1,
-            missing_branches=1,
-        ),
-        files={
-            pathlib.Path("codebase/main.py"): coverage_module.FileCoverage(
-                path=pathlib.Path("codebase/main.py"),
-                executed_lines=[1, 2, 5, 6, 9],
-                missing_lines=[3, 7, 13, 21, 123],
-                excluded_lines=[],
-                info=coverage_module.CoverageInfo(
-                    covered_lines=5,
-                    num_statements=10,
-                    percent_covered=decimal.Decimal("0.5"),
-                    missing_lines=5,
-                    excluded_lines=0,
-                    num_branches=2,
-                    num_partial_branches=1,
-                    covered_branches=1,
-                    missing_branches=1,
-                ),
-            ),
-            pathlib.Path("codebase/caller.py"): coverage_module.FileCoverage(
-                path=pathlib.Path("codebase/caller.py"),
-                executed_lines=[1, 2, 5],
-                missing_lines=[13, 21, 212],
-                excluded_lines=[],
-                info=coverage_module.CoverageInfo(
-                    covered_lines=3,
-                    num_statements=6,
-                    percent_covered=decimal.Decimal("0.5"),
-                    missing_lines=3,
-                    excluded_lines=0,
-                    num_branches=2,
-                    num_partial_branches=1,
-                    covered_branches=1,
-                    missing_branches=1,
-                ),
-            ),
-        },
-    )
-
-
-@pytest.fixture
 def diff_coverage_obj():
     return coverage_module.DiffCoverage(
         total_num_lines=5,
@@ -288,6 +229,28 @@ def diff_coverage_obj():
                 percent_covered=decimal.Decimal("0.8"),
                 violation_lines=[7, 9],
             )
+        },
+    )
+
+
+@pytest.fixture
+def diff_coverage_obj_many_missing_lines():
+    return coverage_module.DiffCoverage(
+        total_num_lines=5,
+        total_num_violations=1,
+        total_percent_covered=decimal.Decimal("0.8"),
+        num_changed_lines=39,
+        files={
+            pathlib.Path("codebase/code.py"): coverage_module.FileDiffCoverage(
+                path=pathlib.Path("codebase/code.py"),
+                percent_covered=decimal.Decimal("0.8"),
+                violation_lines=[7, 9],
+            ),
+            pathlib.Path("codebase/main.py"): coverage_module.FileDiffCoverage(
+                path=pathlib.Path("codebase/code.py"),
+                percent_covered=decimal.Decimal("0.8"),
+                violation_lines=[1, 2, 8, 17],
+            ),
         },
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,8 +153,8 @@ def coverage_obj():
             missing_branches=1,
         ),
         files={
-            "codebase/code.py": coverage_module.FileCoverage(
-                path="codebase/code.py",
+            pathlib.Path("codebase/code.py"): coverage_module.FileCoverage(
+                path=pathlib.Path("codebase/code.py"),
                 executed_lines=[1, 2, 5, 6, 9],
                 missing_lines=[7, 9],
                 excluded_lines=[],
@@ -195,8 +195,8 @@ def coverage_obj_no_branch():
             missing_branches=None,
         ),
         files={
-            "codebase/code.py": coverage_module.FileCoverage(
-                path="codebase/code.py",
+            pathlib.Path("codebase/code.py"): coverage_module.FileCoverage(
+                path=pathlib.Path("codebase/code.py"),
                 executed_lines=[1, 2, 5, 6, 9],
                 missing_lines=[7],
                 excluded_lines=[],
@@ -237,8 +237,8 @@ def coverage_obj_many_missing_lines():
             missing_branches=1,
         ),
         files={
-            "codebase/main.py": coverage_module.FileCoverage(
-                path="codebase/main.py",
+            pathlib.Path("codebase/main.py"): coverage_module.FileCoverage(
+                path=pathlib.Path("codebase/main.py"),
                 executed_lines=[1, 2, 5, 6, 9],
                 missing_lines=[3, 7, 13, 21, 123],
                 excluded_lines=[],
@@ -254,8 +254,8 @@ def coverage_obj_many_missing_lines():
                     missing_branches=1,
                 ),
             ),
-            "codebase/caller.py": coverage_module.FileCoverage(
-                path="codebase/caller.py",
+            pathlib.Path("codebase/caller.py"): coverage_module.FileCoverage(
+                path=pathlib.Path("codebase/caller.py"),
                 executed_lines=[1, 2, 5],
                 missing_lines=[13, 21, 212],
                 excluded_lines=[],
@@ -283,8 +283,8 @@ def diff_coverage_obj():
         total_percent_covered=decimal.Decimal("0.8"),
         num_changed_lines=39,
         files={
-            "codebase/code.py": coverage_module.FileDiffCoverage(
-                path="codebase/code.py",
+            pathlib.Path("codebase/code.py"): coverage_module.FileDiffCoverage(
+                path=pathlib.Path("codebase/code.py"),
                 percent_covered=decimal.Decimal("0.8"),
                 violation_lines=[7, 9],
             )

--- a/tests/integration/test_github.py
+++ b/tests/integration/test_github.py
@@ -1,3 +1,5 @@
+import pathlib
+
 import pytest
 
 from coverage_comment import github
@@ -315,7 +317,7 @@ def test_send_workflow_command(capsys):
 
 def test_create_missing_coverage_annotation(capsys):
     github.create_missing_coverage_annotation(
-        annotation_type="warning", file="test.py", line=42
+        annotation_type="warning", file=pathlib.Path("test.py"), line=42
     )
     output = capsys.readouterr()
     assert (
@@ -326,7 +328,7 @@ def test_create_missing_coverage_annotation(capsys):
 
 def test_create_missing_coverage_annotation__annotation_type(capsys):
     github.create_missing_coverage_annotation(
-        annotation_type="error", file="test.py", line=42
+        annotation_type="error", file=pathlib.Path("test.py"), line=42
     )
     output = capsys.readouterr()
     assert (

--- a/tests/unit/test_annotations.py
+++ b/tests/unit/test_annotations.py
@@ -1,8 +1,10 @@
 from coverage_comment import annotations
 
 
-def test_annotations(coverage_obj, capsys):
-    annotations.create_pr_annotations(annotation_type="warning", coverage=coverage_obj)
+def test_annotations(diff_coverage_obj, capsys):
+    annotations.create_pr_annotations(
+        annotation_type="warning", diff_coverage=diff_coverage_obj
+    )
 
     expected = """::group::Annotations of lines with missing coverage
 ::warning file=codebase/code.py,line=7::This line has no coverage
@@ -12,20 +14,18 @@ def test_annotations(coverage_obj, capsys):
     assert output.err.strip() == expected
 
 
-def test_annotations_several_files(coverage_obj_many_missing_lines, capsys):
+def test_annotations_several_files(diff_coverage_obj_many_missing_lines, capsys):
     annotations.create_pr_annotations(
-        annotation_type="notice", coverage=coverage_obj_many_missing_lines
+        annotation_type="notice", diff_coverage=diff_coverage_obj_many_missing_lines
     )
 
     expected = """::group::Annotations of lines with missing coverage
-::notice file=codebase/main.py,line=3::This line has no coverage
-::notice file=codebase/main.py,line=7::This line has no coverage
-::notice file=codebase/main.py,line=13::This line has no coverage
-::notice file=codebase/main.py,line=21::This line has no coverage
-::notice file=codebase/main.py,line=123::This line has no coverage
-::notice file=codebase/caller.py,line=13::This line has no coverage
-::notice file=codebase/caller.py,line=21::This line has no coverage
-::notice file=codebase/caller.py,line=212::This line has no coverage
+::notice file=codebase/code.py,line=7::This line has no coverage
+::notice file=codebase/code.py,line=9::This line has no coverage
+::notice file=codebase/main.py,line=1::This line has no coverage
+::notice file=codebase/main.py,line=2::This line has no coverage
+::notice file=codebase/main.py,line=8::This line has no coverage
+::notice file=codebase/main.py,line=17::This line has no coverage
 ::endgroup::"""
     output = capsys.readouterr()
     assert output.err.strip() == expected


### PR DESCRIPTION
This is a revamp of https://github.com/py-cov-action/python-coverage-comment-action/pull/188

I believe that the part that failed was:
https://github.com/py-cov-action/python-coverage-comment-action/pull/188/files#diff-5327f4a45499e33cab8758f61e6b738fc200a07b00c58fc231f37a3142461ac7R194-R207

which I removed completely from this PR, as it wasn't needed.

1/ This PR being created by me, we'll get e2e tests
2/ I've remade the commits and remove the things are are much unrelated. We still have a 1st commit that could be somewhat elsewhere, but we were being really inconsistent in types used, and it was visible when switching between cover and diff-cover, so hopefully it's better now