### PR TITLE
e2e tests on external PRs after owner approval

### DIFF
--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -15,6 +15,7 @@ jobs:
       github.event.pull_request.author_association != 'MEMBER'
       && github.event.review.author_association == 'MEMBER'
       && github.event.review.state == 'approved'
+      && contains(github.event.review.body, '/e2e')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -1,0 +1,56 @@
+name: End-to-end tests for external PRs
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  group: ${{ github.event_name }}-${{ github.ref }}
+
+jobs:
+  test:
+    name: Run end to end tests
+    # If reviewed by a repo(/org) owner
+    if: |
+      github.event.pull_request.author_association != 'OWNER'
+      && github.event.review.author_association == 'OWNER
+      && github.event.review.state == 'approved'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          # Important: use the commit that was reviewed. GitHub is making sure
+          # that this is race-condition-proof
+          ref: ${{ github.event.review.commit_id }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: |
+          pipx install poetry --python=python3.10
+
+      - name: Poetry caches
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/
+          key: ${{ hashFiles('poetry.lock') }}
+
+      - name: Install deps
+        run: poetry install
+
+      - name: Run end-to-end tests
+        run: poetry run pytest tests/end_to_end
+        env:
+          COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_1: ${{ secrets.COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_1 }}
+          COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_2: ${{ secrets.COVERAGE_COMMENT_E2E_GITHUB_TOKEN_USER_2 }}
+          COVERAGE_COMMENT_E2E_ACTION_REF: ${{ github.event.review.commit_id }}
+          COVERAGE_COMMENT_E2E_REPO_SUFFIX: ${{ github.event.pull_request.number }}
+          COVERAGE_COMMENT_E2E_PR_AUTHOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -12,8 +12,8 @@ jobs:
     name: Run end to end tests
     # If reviewed by a repo(/org) owner
     if: |
-      github.event.pull_request.author_association != 'OWNER'
-      && github.event.review.author_association == 'OWNER
+      github.event.pull_request.author_association != 'MEMBER'
+      && github.event.review.author_association == 'MEMBER'
       && github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -1,4 +1,4 @@
-name: End-to-end tests for external PRs
+name: External PRs
 
 on:
   pull_request_review:

--- a/.github/workflows/e2e-external.yml
+++ b/.github/workflows/e2e-external.yml
@@ -16,9 +16,6 @@ jobs:
       && github.event.review.author_association == 'MEMBER'
       && github.event.review.state == 'approved'
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR adds a new mechanism to our "not-even-oh-so-slightly-overengineered" CI pipeline:
- When a PR is reviewed
- And it's an approval
- And the PR author is not a repo ~owner~ member
- And the approval author is a repo ~owner~ member
- EDIT: and the review body contains `/e2e`

Then we launch the end to end tests, on the commit that was approved