### PR TITLE
Fix incorrect job name

### DIFF
--- a/.github/workflows/e2e-delete-repo.yml
+++ b/.github/workflows/e2e-delete-repo.yml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   test:
-    name: Publish coverage comment
     runs-on: ubuntu-latest
     steps:
       - run: |


### PR DESCRIPTION
The workflow already has a name, we don't need to duplicate the name in the job, I think.