### PR TITLE
Redo versionning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches:
-      - 'v3'
+    branches: [main]
 
 concurrency:
   group: ${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
-    branches: [v3]
+    branches: [main]
 
 concurrency:
   group: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,3 +34,33 @@ jobs:
           tags: ewjoachim/python-coverage-comment-action-base:v3
           push: true
           file: Dockerfile.build
+
+  compute-tags:
+    name: Re-tag action with new version
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Apply new tags
+        run: |
+          git fetch --tags origin
+          current="$(git describe --tags --abbrev=0 --match 'v*.*.*')"
+
+          tag_major="$(echo $current | cut -d. -f1)"
+          git tag -f ${tag_major}
+          git push -f origin ${tag_major}
+
+          tag_minor="$(echo $current | cut -d. -f1,2)"
+          git tag -f ${tag_minor}
+          git push -f origin ${tag_minor}
+
+          increment=$(echo $current | cut -d. -f3)
+          increment=$((increment + 1))
+          tag_incremental="${tag_minor}.${increment}"
+          git tag ${tag_incremental}
+          git push origin ${tag_incremental}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,11 @@ on:
     types: [completed]
     branches: [v3]
 
+concurrency:
+  group: release
+
 jobs:
-  push_to_registry:
+  push-to-registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
     # Check if the tests were successful and were launched by a push event

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,23 +49,16 @@ jobs:
       - name: Apply new tags
         run: |
           git fetch --tags origin
-          current="$(git describe --tags --abbrev=0 --match 'v*.*.*')"
-          should_bump_minor=$(pipx run conventional list-commits --from-last-tag --parse | jq --slurp 'any(.[]; .data.subject.breaking == "!")')
+          current="$(git describe --tags --abbrev=0 --match 'v*.*')"
 
           major="$(echo $current | cut -d. -f1)"
           minor="$(echo $current | cut -d. -f2)"
-          patch="$(echo $current | cut -d. -f3)"
 
           git tag -f ${major}
           git push -f origin ${major}
 
           # Major releases will be released manually.
-          if [ "${should_bump_minor}" = "true" ]; then
-            minor=$((minor + 1))
-            new_tag="${major}.${minor}.0"
-          else
-            patch=$((patch + 1))
-            new_tag="${major}.${minor}.${patch}"
-          fi
+          patch=$((patch + 1))
+          new_tag="${major}.${minor}"
 
           gh release create ${new_tag} --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,23 +44,28 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Apply new tags
         run: |
           git fetch --tags origin
           current="$(git describe --tags --abbrev=0 --match 'v*.*.*')"
+          should_bump_minor=$(pipx run conventional list-commits --from-last-tag --parse | jq --slurp 'any(.[]; .data.subject.breaking == "!")')
 
-          tag_major="$(echo $current | cut -d. -f1)"
-          git tag -f ${tag_major}
-          git push -f origin ${tag_major}
+          major="$(echo $current | cut -d. -f1)"
+          minor="$(echo $current | cut -d. -f2)"
+          patch="$(echo $current | cut -d. -f3)"
 
-          tag_minor="$(echo $current | cut -d. -f1,2)"
-          git tag -f ${tag_minor}
-          git push -f origin ${tag_minor}
+          git tag -f ${major}
+          git push -f origin ${major}
 
-          increment=$(echo $current | cut -d. -f3)
-          increment=$((increment + 1))
-          tag_incremental="${tag_minor}.${increment}"
-          git tag ${tag_incremental}
-          git push origin ${tag_incremental}
+          # Major releases will be released manually.
+          if [ "${should_bump_minor}" = "true" ]; then
+            minor=$((minor + 1))
+            new_tag="${major}.${minor}.0"
+          else
+            patch=$((patch + 1))
+            new_tag="${major}.${minor}.${patch}"
+          fi
+
+          gh release create ${new_tag} --generate-notes

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ jobs:
 
 By default, comments are generated from a
 [Jinja](https://jinja.palletsprojects.com) template that you can read
-[here](https://github.com/py-cov-action/python-coverage-comment-action/blob/v3/coverage_comment/template_files/comment.md.j2).
+[here](https://github.com/py-cov-action/python-coverage-comment-action/blob/main/coverage_comment/template_files/comment.md.j2).
 
 If you want to change this template, you can set `COMMENT_TEMPLATE`. This is
 an advanced usage, so you're likely to run into more road bumps.

--- a/README.md
+++ b/README.md
@@ -387,13 +387,13 @@ coverage (percentage) of the whole project from the PR build:
 
 ## Pinning
 
-On the examples above, the version was set to the tag `v3`. Pinning to
-a specific version (`v3.1.0` for example) would make the action more
-reproducible, though you'd have to update it regularly (e.g. using Dependabot).
-You can also pin a commit hash if you want to be 100% sure of what you run,
-given that tags are mutable.
-You can also decide to pin to main, if you're ok with the action maybe breaking
-when (if) we release a v4.
+On the examples above, the version was set to the tag `v3`. Pinning to a major version
+will give you the latest release on this version. (Note that we release everytime after
+a PR is merged). Pinning to a specific version (`v3.1` for example) would make the
+action more reproducible, though you'd have to update it regularly (e.g. using
+Dependabot). You can also pin a commit hash if you want to be 100% sure of what you run,
+given that tags are mutable. Finally, You can also decide to pin to main, if you're ok
+with the action maybe breaking when (if) we release a v4.
 
 ## Note on the state of this action
 

--- a/README.md
+++ b/README.md
@@ -387,13 +387,13 @@ coverage (percentage) of the whole project from the PR build:
 
 ## Pinning
 
-On the examples above, the version was set to `v3` (a branch). You can also pin
-a specific version such as `v3.0.0` (a tag). There are still things left to
-figure out in how to manage releases and version. If you're interested, please
-open an issue to discuss this.
-
-In terms of security/reproducibility, the best solution is probably to pin the
-version to an exact tag, and use dependabot to update it regularly.
+On the examples above, the version was set to the tag `v3`. Pinning to
+a specific version (`v3.1.0` for example) would make the action more
+reproducible, though you'd have to update it regularly (e.g. using Dependabot).
+You can also pin a commit hash if you want to be 100% sure of what you run,
+given that tags are mutable.
+You can also decide to pin to main, if you're ok with the action maybe breaking
+when (if) we release a v4.
 
 ## Note on the state of this action
 

--- a/tests/end_to_end/conftest.py
+++ b/tests/end_to_end/conftest.py
@@ -85,7 +85,7 @@ def token_other():
 
 @pytest.fixture
 def action_ref():
-    return os.environ.get("COVERAGE_COMMENT_E2E_ACTION_REF", "v3")
+    return os.environ.get("COVERAGE_COMMENT_E2E_ACTION_REF", "main")
 
 
 @pytest.fixture


### PR DESCRIPTION
Fixes #233 

- Switch to `main` branch
- On each commit to `main`, after tests pass, (re-)tag the action as `vx`, `vx.y` and `vx.y.z`

When this is merged, it's probably worth doing a `v3.1.0`. Also, we need to change the default branch and update the existing PRs, and delete the v3 branch

At this point I have no idea how to handle minor or major versions (e.g. how to make it so when we merge a PR that warrants a version change, it's not immediately released as incremental)