### PR TITLE
Run PR activities on push on non-default branch

### DIFF
--- a/coverage_comment/activity.py
+++ b/coverage_comment/activity.py
@@ -1,0 +1,28 @@
+"""
+This module is responsible for identifying what the action should be doing
+based on the github event type and repository.
+
+The code in main should be as straightforward as possible, we're offloading
+the branching logic to this module.
+"""
+
+
+class ActivityNotFound(Exception):
+    pass
+
+
+def find_activity(
+    event_name: str,
+    is_default_branch: bool,
+) -> str:
+    """Find the activity to perform based on the event type and payload."""
+    if event_name == "workflow_run":
+        return "post_comment"
+
+    if event_name == "push" and is_default_branch:
+        return "save_coverage_data_files"
+
+    if event_name not in {"pull_request", "push"}:
+        raise ActivityNotFound
+
+    return "process_pr"

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -64,7 +64,7 @@ def action(
     event_name = config.GITHUB_EVENT_NAME
     if event_name not in {"pull_request", "push", "workflow_run"}:
         log.error(
-            'This action has only been designed to work for "pull_request", "branch" '
+            'This action has only been designed to work for "pull_request", "push" '
             f'or "workflow_run" actions, not "{event_name}". Because there are security '
             "implications. If you have a different usecase, please open an issue, "
             "we'll be glad to add compatibility."

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -119,11 +119,6 @@ def process_pr(
         base_ref=base_ref, coverage_path=config.COVERAGE_PATH
     )
 
-    if config.ANNOTATE_MISSING_LINES:
-        annotations.create_pr_annotations(
-            annotation_type=config.ANNOTATION_TYPE, diff_coverage=diff_coverage
-        )
-
     previous_coverage_data_file = storage.get_datafile_contents(
         github=gh,
         repository=config.GITHUB_REPOSITORY,
@@ -163,7 +158,7 @@ def process_pr(
     )
 
     pr_number: int | None = config.GITHUB_PR_NUMBER
-    if not pr_number:
+    if pr_number is None:
         # If we don't have a PR number, we're launched from a push event,
         # so we need to find the PR number from the branch name
         assert config.GITHUB_BRANCH_NAME
@@ -177,6 +172,11 @@ def process_pr(
             )
         except github.CannotDeterminePR:
             pr_number = None
+        else:
+            if config.ANNOTATE_MISSING_LINES:
+                annotations.create_pr_annotations(
+                    annotation_type=config.ANNOTATION_TYPE, diff_coverage=diff_coverage
+                )
 
     try:
         if config.FORCE_WORKFLOW_RUN or not pr_number:

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -5,6 +5,7 @@ import sys
 
 import httpx
 
+from coverage_comment import activity as activity_module
 from coverage_comment import annotations, comment_file, communication
 from coverage_comment import coverage as coverage_module
 from coverage_comment import (
@@ -60,9 +61,17 @@ def action(
     git: subprocess.Git,
 ) -> int:
     log.debug(f"Operating on {config.GITHUB_REF}")
-
+    gh = github_client.GitHub(session=github_session)
     event_name = config.GITHUB_EVENT_NAME
-    if event_name not in {"pull_request", "push", "workflow_run"}:
+    repo_info = github.get_repository_info(
+        github=gh, repository=config.GITHUB_REPOSITORY
+    )
+    try:
+        activity = activity_module.find_activity(
+            event_name=event_name,
+            is_default_branch=repo_info.is_default_branch(ref=config.GITHUB_REF),
+        )
+    except activity_module.ActivityNotFound:
         log.error(
             'This action has only been designed to work for "pull_request", "push" '
             f'or "workflow_run" actions, not "{event_name}". Because there are security '
@@ -71,52 +80,49 @@ def action(
         )
         return 1
 
-    if event_name in {"pull_request", "push"}:
-        raw_coverage, coverage = coverage_module.get_coverage_info(
-            merge=config.MERGE_COVERAGE_FILES, coverage_path=config.COVERAGE_PATH
+    if activity == "save_coverage_data_files":
+        return save_coverage_data_files(
+            config=config,
+            git=git,
+            http_session=http_session,
+            repo_info=repo_info,
         )
-        if event_name == "pull_request":
-            diff_coverage = coverage_module.get_diff_coverage_info(
-                base_ref=config.GITHUB_BASE_REF, coverage_path=config.COVERAGE_PATH
-            )
-            if config.ANNOTATE_MISSING_LINES:
-                annotations.create_pr_annotations(
-                    annotation_type=config.ANNOTATION_TYPE, diff_coverage=diff_coverage
-                )
-            return generate_comment(
-                config=config,
-                coverage=coverage,
-                diff_coverage=diff_coverage,
-                github_session=github_session,
-            )
-        else:
-            # event_name == "push"
-            return save_coverage_data_files(
-                config=config,
-                coverage=coverage,
-                raw_coverage_data=raw_coverage,
-                github_session=github_session,
-                git=git,
-                http_session=http_session,
-            )
+
+    elif activity == "process_pr":
+        return process_pr(
+            config=config,
+            gh=gh,
+            repo_info=repo_info,
+        )
 
     else:
-        # event_name == "workflow_run"
+        # activity == "post_comment":
         return post_comment(
             config=config,
-            github_session=github_session,
+            gh=gh,
         )
 
 
-def generate_comment(
+def process_pr(
     config: settings.Config,
-    coverage: coverage_module.Coverage,
-    diff_coverage: coverage_module.DiffCoverage,
-    github_session: httpx.Client,
+    gh: github_client.GitHub,
+    repo_info: github.RepositoryInfo,
 ) -> int:
     log.info("Generating comment for PR")
 
-    gh = github_client.GitHub(session=github_session)
+    _, coverage = coverage_module.get_coverage_info(
+        merge=config.MERGE_COVERAGE_FILES,
+        coverage_path=config.COVERAGE_PATH,
+    )
+    base_ref = config.GITHUB_BASE_REF or repo_info.default_branch
+    diff_coverage = coverage_module.get_diff_coverage_info(
+        base_ref=base_ref, coverage_path=config.COVERAGE_PATH
+    )
+
+    if config.ANNOTATE_MISSING_LINES:
+        annotations.create_pr_annotations(
+            annotation_type=config.ANNOTATION_TYPE, diff_coverage=diff_coverage
+        )
 
     previous_coverage_data_file = storage.get_datafile_contents(
         github=gh,
@@ -152,21 +158,35 @@ def generate_comment(
         )
         return 1
 
-    assert config.GITHUB_PR_NUMBER
-
     github.add_job_summary(
         content=comment, github_step_summary=config.GITHUB_STEP_SUMMARY
     )
 
+    pr_number: int | None = config.GITHUB_PR_NUMBER
+    if not pr_number:
+        # If we don't have a PR number, we're launched from a push event,
+        # so we need to find the PR number from the branch name
+        assert config.GITHUB_BRANCH_NAME
+        try:
+            pr_number = github.find_pr_for_branch(
+                github=gh,
+                # A push event cannot be initiated from a forked repository
+                repository=config.GITHUB_REPOSITORY,
+                owner=config.GITHUB_REPOSITORY.split("/")[0],
+                branch=config.GITHUB_BRANCH_NAME,
+            )
+        except github.CannotDeterminePR:
+            pr_number = None
+
     try:
-        if config.FORCE_WORKFLOW_RUN:
+        if config.FORCE_WORKFLOW_RUN or not pr_number:
             raise github.CannotPostComment
 
         github.post_comment(
             github=gh,
             me=github.get_my_login(github=gh),
             repository=config.GITHUB_REPOSITORY,
-            pr_number=config.GITHUB_PR_NUMBER,
+            pr_number=pr_number,
             contents=comment,
             marker=template.MARKER,
         )
@@ -193,21 +213,29 @@ def generate_comment(
     return 0
 
 
-def post_comment(config: settings.Config, github_session: httpx.Client) -> int:
+def post_comment(
+    config: settings.Config,
+    gh: github_client.GitHub,
+) -> int:
     log.info("Posting comment to PR")
 
     if not config.GITHUB_PR_RUN_ID:
         log.error("Missing input GITHUB_PR_RUN_ID. Please consult the documentation.")
         return 1
 
-    gh = github_client.GitHub(session=github_session)
     me = github.get_my_login(github=gh)
     log.info(f"Search for PR associated with run id {config.GITHUB_PR_RUN_ID}")
+    owner, branch = github.get_branch_from_workflow_run(
+        github=gh,
+        run_id=config.GITHUB_PR_RUN_ID,
+        repository=config.GITHUB_REPOSITORY,
+    )
     try:
-        pr_number = github.get_pr_number_from_workflow_run(
+        pr_number = github.find_pr_for_branch(
             github=gh,
-            run_id=config.GITHUB_PR_RUN_ID,
             repository=config.GITHUB_REPOSITORY,
+            owner=owner,
+            branch=branch,
         )
     except github.CannotDeterminePR:
         log.error(
@@ -250,25 +278,17 @@ def post_comment(config: settings.Config, github_session: httpx.Client) -> int:
 
 def save_coverage_data_files(
     config: settings.Config,
-    coverage: coverage_module.Coverage,
-    raw_coverage_data: dict,
-    github_session: httpx.Client,
     git: subprocess.Git,
     http_session: httpx.Client,
+    repo_info: github.RepositoryInfo,
 ) -> int:
-    gh = github_client.GitHub(session=github_session)
-    repo_info = github.get_repository_info(
-        github=gh,
-        repository=config.GITHUB_REPOSITORY,
-    )
-    is_default_branch = repo_info.is_default_branch(ref=config.GITHUB_REF)
-    log.debug(f"On default branch: {is_default_branch}")
-
-    if not is_default_branch:
-        log.info("Skipping badge save as we're not on the default branch")
-        return 0
-
     log.info("Computing coverage files & badge")
+
+    raw_coverage_data, coverage = coverage_module.get_coverage_info(
+        merge=config.MERGE_COVERAGE_FILES,
+        coverage_path=config.COVERAGE_PATH,
+    )
+
     operations: list[files.Operation] = files.compute_files(
         line_rate=coverage.info.percent_covered,
         raw_coverage_data=raw_coverage_data,

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -167,7 +167,6 @@ def process_pr(
     github.add_job_summary(
         content=comment, github_step_summary=config.GITHUB_STEP_SUMMARY
     )
-
     pr_number: int | None = config.GITHUB_PR_NUMBER
     if pr_number is None:
         # If we don't have a PR number, we're launched from a push event,
@@ -183,11 +182,11 @@ def process_pr(
             )
         except github.CannotDeterminePR:
             pr_number = None
-        else:
-            if config.ANNOTATE_MISSING_LINES:
-                annotations.create_pr_annotations(
-                    annotation_type=config.ANNOTATION_TYPE, diff_coverage=diff_coverage
-                )
+
+    if pr_number is not None and config.ANNOTATE_MISSING_LINES:
+        annotations.create_pr_annotations(
+            annotation_type=config.ANNOTATION_TYPE, diff_coverage=diff_coverage
+        )
 
     try:
         if config.FORCE_WORKFLOW_RUN or not pr_number:

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -125,6 +125,13 @@ class Config:
             return int(self.GITHUB_REF.split("/")[2])
         return None
 
+    @property
+    def GITHUB_BRANCH_NAME(self) -> str | None:
+        # "refs/head/my_branch_name"
+        if "heads" in self.GITHUB_REF:
+            return self.GITHUB_REF.split("/", 2)[2]
+        return None
+
     # We need to type environ as a MutableMapping because that's what
     # os.environ is, and just saying `dict[str, str]` is not enough to make
     # mypy happy

--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -33,9 +33,15 @@ def str_to_bool(value: str) -> bool:
 class Config:
     """This object defines the environment variables"""
 
+    # A branch name, not a fully-formed ref. For example, `main`.
     GITHUB_BASE_REF: str
     GITHUB_TOKEN: str = dataclasses.field(repr=False)
     GITHUB_REPOSITORY: str
+    # > The ref given is fully-formed, meaning that for branches the format is
+    # > `refs/heads/<branch_name>`, for pull requests it is
+    # > `refs/pull/<pr_number>/merge`, and for tags it is `refs/tags/<tag_name>`.
+    # > For example, `refs/heads/feature-branch-1`.
+    # (from https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables )
     GITHUB_REF: str
     GITHUB_EVENT_NAME: str
     GITHUB_PR_RUN_ID: int | None

--- a/coverage_comment/template.py
+++ b/coverage_comment/template.py
@@ -45,6 +45,7 @@ def get_comment_markdown(
     previous_coverage_rate: decimal.Decimal | None,
     base_template: str,
     custom_template: str | None = None,
+    pr_targets_default_branch: bool = True,
 ):
     loader = CommentLoader(base_template=base_template, custom_template=custom_template)
     env = SandboxedEnvironment(loader=loader)
@@ -56,6 +57,7 @@ def get_comment_markdown(
             coverage=coverage,
             diff_coverage=diff_coverage,
             marker=MARKER,
+            pr_targets_default_branch=pr_targets_default_branch,
         )
     except jinja2.exceptions.TemplateError as exc:
         raise TemplateError from exc

--- a/coverage_comment/template_files/comment.md.j2
+++ b/coverage_comment/template_files/comment.md.j2
@@ -15,8 +15,20 @@ The coverage rate went from `{{ previous_coverage_rate | pct }}` to `{{ coverage
 {%- endblock emoji_coverage -%}
 {%- else -%}
 {% block no_comparison_info -%}
-> **Note**
-> No coverage data of the default branch was found for comparison. A possible reason for this is that the coverage action has not yet run after a push event and the data is therefore not yet initialized.
+{%- if pr_targets_default_branch -%}
+{% block no_comparison_info_data_not_found_message -%}
+> [!NOTE]
+> Coverage data for the default branch was not found.
+> This usually happens when the action has not run on the default
+> branch yet, for example right after deploying it into the workflows.
+{%- endblock no_comparison_info_data_not_found_message -%}
+{% else %}
+{% block no_comparison_info_non_default_target -%}
+> [!NOTE]
+> Coverage evolution disabled because this PR targets a different branch
+> than the default branch, for which coverage data is not available.
+{%- endblock no_comparison_info_non_default_target -%}
+{% endif %}
 {%- endblock no_comparison_info %}
 
 {% block coverage_value_wording -%}

--- a/coverage_comment/template_files/comment.md.j2
+++ b/coverage_comment/template_files/comment.md.j2
@@ -27,8 +27,8 @@ The coverage rate went from `{{ previous_coverage_rate | pct }}` to `{{ coverage
 > [!NOTE]
 > Coverage evolution disabled because this PR targets a different branch
 > than the default branch, for which coverage data is not available.
-{%- endblock no_comparison_info_non_default_target -%}
-{% endif %}
+{%- endblock no_comparison_info_non_default_target %}
+{%- endif %}
 {%- endblock no_comparison_info %}
 
 {% block coverage_value_wording -%}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ markers = [
     "repo_suffix: Allows to use an additional suffix for the e2e test repo.",
     "code_path: Allows to place the code in a subdirectory for the e2e test repo.",
     "subproject_id: Allows to use a different subproject id for the e2e test repo.",
+    "add_branches: Adds branches besides 'main' and 'branch' to integration tests setup.",
 ]
 
 [tool.coverage.run]

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -96,9 +96,28 @@ def integration_env(integration_dir, write_file, run_coverage, commit):
     subprocess.check_call(["git", "fetch", "origin"], cwd=integration_dir)
 
 
+def test_action__invalid_event_name(session, push_config, in_integration_env, get_logs):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
+    result = main.action(
+        config=push_config(GITHUB_EVENT_NAME="pull_request_target"),
+        github_session=session,
+        http_session=session,
+        git=None,
+    )
+
+    assert result == 1
+    assert get_logs("ERROR", "This action has only been designed to work for")
+
+
 def test_action__pull_request__store_comment(
     pull_request_config, session, in_integration_env, output_file, summary_file, capsys
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
     # No existing badge in this test
     session.register(
         "GET",
@@ -161,6 +180,10 @@ def test_action__pull_request__store_comment(
 def test_action__pull_request__post_comment(
     pull_request_config, session, in_integration_env, output_file, summary_file
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
     payload = json.dumps({"coverage": 30.00})
     # There is an existing badge in this test, allowing to test the coverage evolution
     session.register(
@@ -210,9 +233,135 @@ def test_action__pull_request__post_comment(
     assert output_file.read_text() == expected_output
 
 
+def test_action__push__non_default_branch(
+    push_config, session, in_integration_env, output_file, summary_file
+):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
+    payload = json.dumps({"coverage": 30.00})
+    # There is an existing badge in this test, allowing to test the coverage evolution
+    session.register(
+        "GET",
+        "/repos/py-cov-action/foobar/contents/data.json",
+    )(json={"content": base64.b64encode(payload.encode()).decode()})
+
+    session.register(
+        "GET",
+        "/repos/py-cov-action/foobar/pulls",
+        params={
+            "state": "open",
+            "head": "py-cov-action:other",
+            "sort": "updated",
+            "direction": "desc",
+        },
+    )(json=[{"number": 2}])
+
+    # Who am I
+    session.register("GET", "/user")(json={"login": "foo"})
+    # Are there already comments
+    session.register("GET", "/repos/py-cov-action/foobar/issues/2/comments")(json=[])
+
+    comment = None
+
+    def checker(payload):
+        body = payload["body"]
+        assert "## Coverage report" in body
+        nonlocal comment
+        comment = body
+        return True
+
+    # Post a new comment
+    session.register(
+        "POST",
+        "/repos/py-cov-action/foobar/issues/2/comments",
+        json=checker,
+    )(
+        status_code=200,
+    )
+    result = main.action(
+        config=push_config(
+            GITHUB_REF="refs/heads/other",
+            GITHUB_STEP_SUMMARY=summary_file,
+            GITHUB_OUTPUT=output_file,
+        ),
+        github_session=session,
+        http_session=session,
+        git=None,
+    )
+    assert result == 0
+
+    assert not pathlib.Path("python-coverage-comment-action.txt").exists()
+    assert "The coverage rate went from `30%` to `77.77%` :arrow_up:" in comment
+    assert comment == summary_file.read_text()
+
+    expected_output = "COMMENT_FILE_WRITTEN=false\n"
+
+    assert output_file.read_text() == expected_output
+
+
+def test_action__push__non_default_branch__no_pr(
+    push_config, session, in_integration_env, output_file, summary_file
+):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
+    payload = json.dumps({"coverage": 30.00})
+    # There is an existing badge in this test, allowing to test the coverage evolution
+    session.register(
+        "GET",
+        "/repos/py-cov-action/foobar/contents/data.json",
+    )(json={"content": base64.b64encode(payload.encode()).decode()})
+
+    session.register(
+        "GET",
+        "/repos/py-cov-action/foobar/pulls",
+        params={
+            "state": "open",
+            "head": "py-cov-action:other",
+            "sort": "updated",
+            "direction": "desc",
+        },
+    )(json=[])
+    session.register(
+        "GET",
+        "/repos/py-cov-action/foobar/pulls",
+        params={
+            "state": "all",
+            "head": "py-cov-action:other",
+            "sort": "updated",
+            "direction": "desc",
+        },
+    )(json=[])
+
+    result = main.action(
+        config=push_config(
+            GITHUB_REF="refs/heads/other",
+            GITHUB_STEP_SUMMARY=summary_file,
+            GITHUB_OUTPUT=output_file,
+        ),
+        github_session=session,
+        http_session=session,
+        git=None,
+    )
+    assert result == 0
+
+    assert pathlib.Path("python-coverage-comment-action.txt").exists()
+
+    expected_output = "COMMENT_FILE_WRITTEN=true\n"
+
+    assert output_file.read_text() == expected_output
+
+
 def test_action__pull_request__force_store_comment(
     pull_request_config, session, in_integration_env, output_file
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
     payload = json.dumps({"coverage": 30.00})
     # There is an existing badge in this test, allowing to test the coverage evolution
     session.register(
@@ -238,6 +387,10 @@ def test_action__pull_request__force_store_comment(
 def test_action__pull_request__post_comment__no_marker(
     pull_request_config, session, in_integration_env, get_logs
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
     # No existing badge in this test
     session.register(
         "GET",
@@ -257,6 +410,9 @@ def test_action__pull_request__post_comment__no_marker(
 def test_action__pull_request__annotations(
     pull_request_config, session, in_integration_env, capsys
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
     # No existing badge in this test
     session.register(
         "GET",
@@ -292,6 +448,10 @@ def test_action__pull_request__annotations(
 def test_action__pull_request__post_comment__template_error(
     pull_request_config, session, in_integration_env, get_logs
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
     # No existing badge in this test
     session.register(
         "GET",
@@ -306,24 +466,6 @@ def test_action__pull_request__post_comment__template_error(
     )
     assert result == 1
     assert get_logs("ERROR", "There was a rendering error")
-
-
-def test_action__push__non_default_branch(
-    push_config, session, in_integration_env, get_logs
-):
-    session.register("GET", "/repos/py-cov-action/foobar")(
-        json={"default_branch": "main", "visibility": "public"}
-    )
-
-    result = main.action(
-        config=push_config(GITHUB_REF="refs/heads/master"),
-        github_session=session,
-        http_session=session,
-        git=None,
-    )
-    assert result == 0
-
-    assert get_logs("INFO", "Skipping badge")
 
 
 def test_action__push__default_branch(
@@ -435,14 +577,35 @@ See more details and ready-to-copy-paste-markdown at:
     assert log == expected
 
 
+def test_action__workflow_run__no_pr_number(
+    workflow_run_config, session, in_integration_env, get_logs
+):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
+
+    result = main.action(
+        config=workflow_run_config(GITHUB_PR_RUN_ID=None),
+        github_session=session,
+        http_session=session,
+        git=None,
+    )
+
+    assert result == 1
+    assert get_logs("ERROR", "Missing input GITHUB_PR_RUN_ID")
+
+
 def test_action__workflow_run__no_pr(
     workflow_run_config, session, in_integration_env, get_logs
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
     session.register("GET", "/user")(json={"login": "foo"})
     session.register("GET", "/repos/py-cov-action/foobar/actions/runs/123")(
         json={
             "head_branch": "branch",
-            "head_repository": {"full_name": "bar/repo-name"},
+            "head_repository": {"owner": {"login": "bar/repo-name"}},
         }
     )
 
@@ -481,11 +644,14 @@ def test_action__workflow_run__no_pr(
 def test_action__workflow_run__no_artifact(
     workflow_run_config, session, in_integration_env, get_logs
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
     session.register("GET", "/user")(json={"login": "foo"})
     session.register("GET", "/repos/py-cov-action/foobar/actions/runs/123")(
         json={
             "head_branch": "branch",
-            "head_repository": {"full_name": "bar/repo-name"},
+            "head_repository": {"owner": {"login": "bar/repo-name"}},
         }
     )
 
@@ -519,11 +685,14 @@ def test_action__workflow_run__no_artifact(
 def test_action__workflow_run__post_comment(
     workflow_run_config, session, in_integration_env, get_logs, zip_bytes, summary_file
 ):
+    session.register("GET", "/repos/py-cov-action/foobar")(
+        json={"default_branch": "main", "visibility": "public"}
+    )
     session.register("GET", "/user")(json={"login": "foo"})
     session.register("GET", "/repos/py-cov-action/foobar/actions/runs/123")(
         json={
             "head_branch": "branch",
-            "head_repository": {"full_name": "bar/repo-name"},
+            "head_repository": {"owner": {"login": "bar/repo-name"}},
         }
     )
 

--- a/tests/unit/test_activity.py
+++ b/tests/unit/test_activity.py
@@ -1,0 +1,25 @@
+import pytest
+
+from coverage_comment import activity
+
+
+@pytest.mark.parametrize(
+    "event_name, is_default_branch, expected_activity",
+    [
+        ("workflow_run", True, "post_comment"),
+        ("push", True, "save_coverage_data_files"),
+        ("push", False, "process_pr"),
+        ("pull_request", True, "process_pr"),
+        ("pull_request", False, "process_pr"),
+    ],
+)
+def test_find_activity(event_name, is_default_branch, expected_activity):
+    result = activity.find_activity(
+        event_name=event_name, is_default_branch=is_default_branch
+    )
+    assert result == expected_activity
+
+
+def test_find_activity_not_found():
+    with pytest.raises(activity.ActivityNotFound):
+        activity.find_activity(event_name="not_found", is_default_branch=False)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -5,28 +5,6 @@ import httpx
 from coverage_comment import main, settings, subprocess
 
 
-def test_action__invalid_event_name(push_config, get_logs):
-    result = main.action(
-        config=push_config(GITHUB_EVENT_NAME="pull_request_target"),
-        github_session=None,
-        http_session=None,
-        git=None,
-    )
-
-    assert result == 1
-    assert get_logs("ERROR", "This action has only been designed to work for")
-
-
-def test_post_comment__no_run_id(workflow_run_config, get_logs):
-    result = main.post_comment(
-        config=workflow_run_config(GITHUB_PR_RUN_ID=""),
-        github_session=None,
-    )
-
-    assert result == 1
-    assert get_logs("ERROR", "Missing input GITHUB_PR_RUN_ID")
-
-
 def test_main(mocker, get_logs):
     # This test is a mock festival. The idea is that all the things that are hard
     # to simulate without mocks have been pushed up the stack up to this function

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -130,6 +130,17 @@ def test_config__GITHUB_PR_NUMBER(config, github_ref, github_pr_number):
     assert config(GITHUB_REF=github_ref).GITHUB_PR_NUMBER == github_pr_number
 
 
+@pytest.mark.parametrize(
+    "github_ref, github_branch_name",
+    [
+        ("refs/pull/2/merge", None),
+        ("refs/heads/a/b", "a/b"),
+    ],
+)
+def test_config__GITHUB_BRANCH_NAME(config, github_ref, github_branch_name):
+    assert config(GITHUB_REF=github_ref).GITHUB_BRANCH_NAME == github_branch_name
+
+
 def test_config__from_environ__error():
     with pytest.raises(ValueError):
         settings.Config.from_environ({"COMMENT_FILENAME": "/a"})

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -204,8 +204,10 @@ def test_template__no_branch_no_previous(coverage_obj_no_branch, diff_coverage_o
         base_template=template.read_template_file("comment.md.j2"),
     )
     expected = """## Coverage report
-> **Note**
-> No coverage data of the default branch was found for comparison. A possible reason for this is that the coverage action has not yet run after a push event and the data is therefore not yet initialized.
+> [!NOTE]
+> Coverage data for the default branch was not found.
+> This usually happens when the action has not run on the default
+> branch yet, for example right after deploying it into the workflows.
 
 The coverage rate is `75%`.
 


### PR DESCRIPTION
Closes #234, Closes #246

Still needs:
- Manual tests
- A decision regarding whether we need e2e tests for that or not
- Documentation (especially on how to write the part that posts the comment from the artifact. Though it will be very much like CommentPR.yml from [here](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/))

But the code is written, and we already have 100% coverage so that's a good start.