### PR TITLE
Split release into "automated" (@v3) and "manual" (@v3.x)

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -1,0 +1,35 @@
+name: Release Action (manual)
+
+on: workflow_dispatch
+
+concurrency:
+  group: release
+
+jobs:
+  release:
+    name: Create new release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -eux
+          current="$(git describe --tags --abbrev=0 --match 'v*.*')"
+
+          major="$(echo $current | cut -d. -f1)"
+          minor="$(echo $current | cut -d. -f2)"
+
+          # Major releases will be released manually.
+          minor=$((minor + 1))
+          new_tag="${major}.${minor}"
+
+          gh release create ${new_tag} --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,4 @@
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Release Action
+name: Release Action (automated)
 
 on:
   workflow_run:
@@ -61,9 +56,3 @@ jobs:
 
           git tag -f ${major}
           git push -f origin ${major}
-
-          # Major releases will be released manually.
-          minor=$((minor + 1))
-          new_tag="${major}.${minor}"
-
-          gh release create ${new_tag} --generate-notes


### PR DESCRIPTION
As discussed with @kieferro : there will be a manual button for releasing when we want to release. The @v3 tag will be automatically re-pushed after every commit.