### PR TITLE
Also store raw coverage information on data branch

### DIFF
--- a/coverage_comment/coverage.py
+++ b/coverage_comment/coverage.py
@@ -67,13 +67,15 @@ def compute_coverage(num_covered: int, num_total: int) -> decimal.Decimal:
     return decimal.Decimal(num_covered) / decimal.Decimal(num_total)
 
 
-def get_coverage_info(merge: bool, coverage_path: pathlib.Path) -> Coverage:
+def get_coverage_info(
+    merge: bool, coverage_path: pathlib.Path
+) -> tuple[dict, Coverage]:
     try:
         if merge:
             subprocess.run("coverage", "combine", path=coverage_path)
 
-        json_coverage = subprocess.run(
-            "coverage", "json", "-o", "-", path=coverage_path
+        json_coverage = json.loads(
+            subprocess.run("coverage", "json", "-o", "-", path=coverage_path)
         )
     except subprocess.SubProcessError as exc:
         if "No source for code:" in str(exc):
@@ -89,7 +91,7 @@ def get_coverage_info(merge: bool, coverage_path: pathlib.Path) -> Coverage:
             )
         raise
 
-    return extract_info(data=json.loads(json_coverage), coverage_path=coverage_path)
+    return json_coverage, extract_info(data=json_coverage, coverage_path=coverage_path)
 
 
 def generate_coverage_html_files(

--- a/coverage_comment/files.py
+++ b/coverage_comment/files.py
@@ -58,6 +58,7 @@ class ReplaceDir:
 
 def compute_files(
     line_rate: decimal.Decimal,
+    raw_coverage_data: dict,
     minimum_green: decimal.Decimal,
     minimum_orange: decimal.Decimal,
     http_session: httpx.Client,
@@ -77,7 +78,10 @@ def compute_files(
         ),
         WriteFile(
             path=DATA_PATH,
-            contents=compute_datafile(line_rate=line_rate),
+            contents=compute_datafile(
+                raw_coverage_data=raw_coverage_data,
+                line_rate=line_rate,
+            ),
         ),
         WriteFile(
             path=BADGE_PATH,
@@ -88,8 +92,8 @@ def compute_files(
     ]
 
 
-def compute_datafile(line_rate: decimal.Decimal) -> str:
-    return json.dumps({"coverage": float(line_rate)})
+def compute_datafile(raw_coverage_data: dict, line_rate: decimal.Decimal) -> str:
+    return json.dumps({"coverage": float(line_rate), "raw_data": raw_coverage_data})
 
 
 def parse_datafile(contents) -> decimal.Decimal:

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -72,7 +72,7 @@ def action(
         return 1
 
     if event_name in {"pull_request", "push"}:
-        coverage = coverage_module.get_coverage_info(
+        raw_coverage, coverage = coverage_module.get_coverage_info(
             merge=config.MERGE_COVERAGE_FILES, coverage_path=config.COVERAGE_PATH
         )
         if event_name == "pull_request":
@@ -94,6 +94,7 @@ def action(
             return save_coverage_data_files(
                 config=config,
                 coverage=coverage,
+                raw_coverage_data=raw_coverage,
                 github_session=github_session,
                 git=git,
                 http_session=http_session,
@@ -250,6 +251,7 @@ def post_comment(config: settings.Config, github_session: httpx.Client) -> int:
 def save_coverage_data_files(
     config: settings.Config,
     coverage: coverage_module.Coverage,
+    raw_coverage_data: dict,
     github_session: httpx.Client,
     git: subprocess.Git,
     http_session: httpx.Client,
@@ -269,6 +271,7 @@ def save_coverage_data_files(
     log.info("Computing coverage files & badge")
     operations: list[files.Operation] = files.compute_files(
         line_rate=coverage.info.percent_covered,
+        raw_coverage_data=raw_coverage_data,
         minimum_green=config.MINIMUM_GREEN,
         minimum_orange=config.MINIMUM_ORANGE,
         http_session=http_session,

--- a/tests/end_to_end/test_all.py
+++ b/tests/end_to_end/test_all.py
@@ -94,6 +94,8 @@ def test_public_repo(
     # unit tests are for.
     data = client.get(f"{raw_url_prefix}/data.json", follow_redirects=True).json()
     assert "coverage" in data
+    assert "raw_data" in data
+    assert "meta" in data["raw_data"]
 
     endpoint = client.get(
         f"{raw_url_prefix}/endpoint.json", follow_redirects=True

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -28,7 +28,9 @@ def test_get_coverage_info(mocker, coverage_json, coverage_obj):
         "coverage_comment.subprocess.run", return_value=json.dumps(coverage_json)
     )
 
-    result = coverage.get_coverage_info(merge=True, coverage_path=pathlib.Path("."))
+    raw_coverage_information, result = coverage.get_coverage_info(
+        merge=True, coverage_path=pathlib.Path(".")
+    )
 
     assert run.call_args_list == [
         mocker.call("coverage", "combine", path=pathlib.Path(".")),
@@ -36,6 +38,7 @@ def test_get_coverage_info(mocker, coverage_json, coverage_obj):
     ]
 
     assert result == coverage_obj
+    assert raw_coverage_information == coverage_json
 
 
 def test_get_coverage_info__no_merge(mocker, coverage_json):

--- a/tests/unit/test_files.py
+++ b/tests/unit/test_files.py
@@ -31,6 +31,7 @@ def test_compute_files(session):
 
     result = files.compute_files(
         line_rate=decimal.Decimal("0.1234"),
+        raw_coverage_data={"foo": ["bar", "bar2"]},
         minimum_green=decimal.Decimal("25"),
         minimum_orange=decimal.Decimal("70"),
         http_session=session,
@@ -40,7 +41,10 @@ def test_compute_files(session):
             path=pathlib.Path("endpoint.json"),
             contents='{"schemaVersion": 1, "label": "Coverage", "message": "12%", "color": "red"}',
         ),
-        files.WriteFile(path=pathlib.Path("data.json"), contents='{"coverage": 12.34}'),
+        files.WriteFile(
+            path=pathlib.Path("data.json"),
+            contents='{"coverage": 12.34, "raw_data": {"foo": ["bar", "bar2"]}}',
+        ),
         files.WriteFile(path=pathlib.Path("badge.svg"), contents="foo"),
     ]
     assert result == expected
@@ -48,8 +52,11 @@ def test_compute_files(session):
 
 def test_compute_datafile():
     assert (
-        files.compute_datafile(line_rate=decimal.Decimal("12.34"))
-        == """{"coverage": 12.34}"""
+        files.compute_datafile(
+            line_rate=decimal.Decimal("12.34"),
+            raw_coverage_data={"meta": {"version": "5.5"}},
+        )
+        == """{"coverage": 12.34, "raw_data": {"meta": {"version": "5.5"}}}"""
     )
 
 


### PR DESCRIPTION
Prepares #211

With the current redesign for the new coverage comment, we need more information about the coverage on the default branch.
The easiest way to make sure that we have all the data we need, is to simply store the raw JSON coverage data on the coverage data branch.
This is not used yet, but the sooner we ship this change, the more repos will have a push event between this change and the merge of #211, which leads to more cases where all data is available.