### PR TITLE
Small release system improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Coverage comment
         id: coverage_comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@main
         with:
           GITHUB_TOKEN: ${{ github.token }}
           ANNOTATE_MISSING_LINES: true

--- a/.github/workflows/coverage-comment.yml
+++ b/.github/workflows/coverage-comment.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Post comment
-        uses: py-cov-action/python-coverage-comment-action@v3
+        uses: py-cov-action/python-coverage-comment-action@main
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -32,4 +32,4 @@ jobs:
           minor=$((minor + 1))
           new_tag="${major}.${minor}"
 
-          gh release create ${new_tag} --generate-notes
+          gh release create ${new_tag} --generate-notes --notes-start-tag ${current}


### PR DESCRIPTION
I noticed two things regarding the releases:
* We always use the action version from one push before for our own CI because the `v3` force-push is done after our CI runs. I would suggest that we always use the very latest version instead, which generally makes sense as we know what we change, but also results in the v3 tag not being pushed if our own usage of the action fails in the CI.
* Release notes are created relative to the latest tag, which in most cases is v3, but we want them relative to the latest minor version. (I fixed this for [v3.9](https://github.com/py-cov-action/python-coverage-comment-action/releases/tag/v3.9) by hand)