### PR TITLE
Remove diff cover

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           # See Dockerfile.build for instructions on bumping this.
-          tags: ewjoachim/python-coverage-comment-action-base:v3
+          tags: ewjoachim/python-coverage-comment-action-base:v4
           push: true
           file: Dockerfile.build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See Dockerfile.build for instructions on bumping this.
-FROM ewjoachim/python-coverage-comment-action-base:v3
+FROM ewjoachim/python-coverage-comment-action-base:v4
 
 COPY coverage_comment ./coverage_comment
 RUN pip install .

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,6 +1,6 @@
 # If you change anything here, bump the version in:
 # - Dockerfile
-# - .github/workflows/docker.yml
+# - .github/workflows/release.yml
 
 FROM python:3.11-slim
 

--- a/coverage_comment/coverage.py
+++ b/coverage_comment/coverage.py
@@ -238,30 +238,26 @@ def get_diff_coverage_info(
 
         missing = set(file.missing_lines) & set(added_lines_for_file)
         count_missing = len(missing)
-        # We don't want to count twice the lines that are both executed and
-        # missing (e.g. the branch lines partially executed)
-        count_total = len(executed | missing)
+        # Even partially covered lines are considered as covered, no line
+        # appears in both counts
+        count_total = count_executed + count_missing
 
         total_num_lines += count_total
         total_num_violations += count_missing
 
-        percent_covered = decimal.Decimal("1")
-        if count_total != 0:
-            # You can't multiply a decimal by a float but you can divide it
-            # by an int, that's why we split the following into 2 lines
-            percent_covered *= count_executed
-            percent_covered /= count_total
+        percent_covered = compute_coverage(
+            num_covered=count_executed, num_total=count_total
+        )
 
         files[path] = FileDiffCoverage(
             path=path,
             percent_covered=percent_covered,
             violation_lines=sorted(missing),
         )
-    final_percentage = decimal.Decimal("1")
-
-    if total_num_lines + total_num_violations != 0:
-        final_percentage *= total_num_lines - total_num_violations
-        final_percentage /= total_num_lines
+    final_percentage = compute_coverage(
+        num_covered=total_num_lines - total_num_violations,
+        num_total=total_num_lines,
+    )
 
     return DiffCoverage(
         total_num_lines=total_num_lines,

--- a/coverage_comment/main.py
+++ b/coverage_comment/main.py
@@ -93,6 +93,7 @@ def action(
             config=config,
             gh=gh,
             repo_info=repo_info,
+            git=git,
         )
 
     else:
@@ -107,6 +108,7 @@ def process_pr(
     config: settings.Config,
     gh: github_client.GitHub,
     repo_info: github.RepositoryInfo,
+    git: subprocess.Git,
 ) -> int:
     log.info("Generating comment for PR")
 
@@ -115,10 +117,11 @@ def process_pr(
         coverage_path=config.COVERAGE_PATH,
     )
     base_ref = config.GITHUB_BASE_REF or repo_info.default_branch
-    diff_coverage = coverage_module.get_diff_coverage_info(
-        base_ref=base_ref, coverage_path=config.COVERAGE_PATH
-    )
 
+    added_lines = coverage_module.get_added_lines(git=git, base_ref=base_ref)
+    diff_coverage = coverage_module.get_diff_coverage_info(
+        coverage=coverage, added_lines=added_lines
+    )
     # It only really makes sense to display a comparison with the previous
     # coverage if the PR target is the branch in which the coverage data is
     # stored, e.g. the default branch.

--- a/coverage_comment/subprocess.py
+++ b/coverage_comment/subprocess.py
@@ -48,7 +48,7 @@ class Git:
         # When setting the `env` argument to run, instead of inheriting env
         # vars from the current process, the whole environment of the
         # subprocess is whatever we pass. In other words, we can either
-        # conditionnaly pass an `env` parameter, but it's less readable,
+        # conditionally pass an `env` parameter, but it's less readable,
         # or we can always pass an `env` parameter, but in this case, we
         # need to always merge `os.environ` to it (and ensure our variables
         # have precedence)

--- a/poetry.lock
+++ b/poetry.lock
@@ -76,17 +76,6 @@ files = [
 ]
 
 [[package]]
-name = "chardet"
-version = "5.2.0"
-description = "Universal encoding detector for Python 3"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "chardet-5.2.0-py3-none-any.whl", hash = "sha256:e1cf59446890a00105fe7b7912492ea04b6e6f06d4b742b2c788469e34c82970"},
-    {file = "chardet-5.2.0.tar.gz", hash = "sha256:1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7"},
-]
-
-[[package]]
 name = "click"
 version = "8.1.7"
 description = "Composable command line interface toolkit"
@@ -174,26 +163,6 @@ files = [
 
 [package.extras]
 toml = ["tomli"]
-
-[[package]]
-name = "diff-cover"
-version = "7.7.0"
-description = "Run coverage and linting reports on diffs"
-optional = false
-python-versions = ">=3.7.2,<4.0.0"
-files = [
-    {file = "diff_cover-7.7.0-py3-none-any.whl", hash = "sha256:bf86f32ec999f9a9e79bf24969f7127ea7b4e55c3ef3cd9300feb13188c89736"},
-    {file = "diff_cover-7.7.0.tar.gz", hash = "sha256:60614cf7e722cf7fb1bde497afac0b514294e1e26534449622dac4da296123fb"},
-]
-
-[package.dependencies]
-chardet = ">=3.0.0"
-Jinja2 = ">=2.7.1"
-pluggy = ">=0.13.1,<2"
-Pygments = ">=2.9.0,<3.0.0"
-
-[package.extras]
-toml = ["tomli (>=1.2.1)"]
 
 [[package]]
 name = "flake8"
@@ -387,16 +356,6 @@ files = [
     {file = "MarkupSafe-2.1.3-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:5bbe06f8eeafd38e5d0a4894ffec89378b6c6a625ff57e3028921f8ff59318ac"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win32.whl", hash = "sha256:dd15ff04ffd7e05ffcb7fe79f1b98041b8ea30ae9234aed2a9168b5797c3effb"},
     {file = "MarkupSafe-2.1.3-cp311-cp311-win_amd64.whl", hash = "sha256:134da1eca9ec0ae528110ccc9e48041e0828d79f24121a1a146161103c76e686"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f698de3fd0c4e6972b92290a45bd9b1536bffe8c6759c62471efaa8acb4c37bc"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:aa57bd9cf8ae831a362185ee444e15a93ecb2e344c8e52e4d721ea3ab6ef1823"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffcc3f7c66b5f5b7931a5aa68fc9cecc51e685ef90282f4a82f0f5e9b704ad11"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47d4f1c5f80fc62fdd7777d0d40a2e9dda0a05883ab11374334f6c4de38adffd"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1f67c7038d560d92149c060157d623c542173016c4babc0c1913cca0564b9939"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:9aad3c1755095ce347e26488214ef77e0485a3c34a50c5a5e2471dff60b9dd9c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:14ff806850827afd6b07a5f32bd917fb7f45b046ba40c57abdb636674a8b559c"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8f9293864fe09b8149f0cc42ce56e3f0e54de883a9de90cd427f191c346eb2e1"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win32.whl", hash = "sha256:715d3562f79d540f251b99ebd6d8baa547118974341db04f5ad06d5ea3eb8007"},
-    {file = "MarkupSafe-2.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:1b8dd8c3fd14349433c79fa8abeb573a55fc0fdd769133baac1f5e07abf54aeb"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8e254ae696c88d98da6555f5ace2279cf7cd5b3f52be2b5cf97feafe883b58d2"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb0932dc158471523c9637e807d9bfb93e06a95cbf010f1a38b98623b929ef2b"},
     {file = "MarkupSafe-2.1.3-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9402b03f1a1b4dc4c19845e5c749e3ab82d5078d16a2a4c2cd2df62d57bb0707"},
@@ -571,20 +530,6 @@ files = [
 ]
 
 [[package]]
-name = "pygments"
-version = "2.16.1"
-description = "Pygments is a syntax highlighting package written in Python."
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "Pygments-2.16.1-py3-none-any.whl", hash = "sha256:13fc09fa63bc8d8671a6d247e1eb303c4b343eaee81d861f3404db2935653692"},
-    {file = "Pygments-2.16.1.tar.gz", hash = "sha256:1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"},
-]
-
-[package.extras]
-plugins = ["importlib-metadata"]
-
-[[package]]
 name = "pytest"
 version = "7.4.2"
 description = "pytest: simple powerful testing with Python"
@@ -678,4 +623,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2b0320a2be9cf2c4e6194be199a89e96d92f5c3c930e42b003c583eb6f4b6a00"
+content-hash = "e2d7b0a1cd3ffd18dd10635b0bafb56547aabb41ca0d3a3e7ff816114261dd3b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ coverage_comment = 'coverage_comment.main:main'
 [tool.poetry.dependencies]
 python = "^3.11"
 coverage = { version = "*", extras = ["toml"] }
-diff-cover = "*"
 httpx = { version = "*", extras = ["http2"] }
 Jinja2 = "*"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -371,7 +371,7 @@ def git(is_failed):
     You get a git object. Register calls on it:
         git.register("git checkout master")(exit_code=1)
     or
-        session.register("git commit", env={"A": "B"})(stdout="Changed branch")
+        git.register("git commit", env={"A": "B"})(stdout="Changed branch")
 
     If the command was not received by the end of the test, it will raise.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,25 +114,6 @@ def coverage_json():
 
 
 @pytest.fixture
-def diff_coverage_json():
-    return {
-        "report_name": "XML",
-        "diff_name": "master...HEAD, staged and unstaged changes",
-        "src_stats": {
-            "codebase/code.py": {
-                "percent_covered": 80.0,
-                "violation_lines": [9],
-                "violations": [[9, None]],
-            }
-        },
-        "total_num_lines": 5,
-        "total_num_violations": 1,
-        "total_percent_covered": 80,
-        "num_changed_lines": 39,
-    }
-
-
-@pytest.fixture
 def coverage_obj():
     return coverage_module.Coverage(
         meta=coverage_module.CoverageMetadata(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -184,7 +184,7 @@ def coverage_obj_no_branch():
                 info=coverage_module.CoverageInfo(
                     covered_lines=5,
                     num_statements=6,
-                    percent_covered=decimal.Decimal("0.75"),
+                    percent_covered=decimal.Decimal("0.8333"),
                     missing_lines=1,
                     excluded_lines=0,
                     num_branches=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,6 +198,41 @@ def coverage_obj_no_branch():
 
 
 @pytest.fixture
+def coverage_obj_more_files(coverage_obj_no_branch):
+    coverage_obj_no_branch.files[
+        pathlib.Path("codebase/other.py")
+    ] = coverage_module.FileCoverage(
+        path=pathlib.Path("codebase/other.py"),
+        executed_lines=[10, 11, 12],
+        missing_lines=[13],
+        excluded_lines=[],
+        info=coverage_module.CoverageInfo(
+            covered_lines=3,
+            num_statements=4,
+            percent_covered=decimal.Decimal("0.75"),
+            missing_lines=1,
+            excluded_lines=0,
+            num_branches=None,
+            num_partial_branches=None,
+            covered_branches=None,
+            missing_branches=None,
+        ),
+    )
+    return coverage_obj_no_branch
+
+
+@pytest.fixture
+def make_coverage_obj(coverage_obj_more_files):
+    def f(**kwargs):
+        obj = coverage_obj_more_files
+        for key, value in kwargs.items():
+            vars(obj.files[pathlib.Path(key)]).update(value)
+        return obj
+
+    return f
+
+
+@pytest.fixture
 def diff_coverage_obj():
     return coverage_module.DiffCoverage(
         total_num_lines=5,

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -170,7 +170,8 @@ def test_action__pull_request__store_comment(
         "POST", "/repos/py-cov-action/foobar/issues/2/comments", json=checker
     )(status_code=403)
 
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     result = main.action(
         config=pull_request_config(
@@ -245,7 +246,8 @@ def test_action__pull_request__store_comment_not_targeting_default(
         "POST", "/repos/py-cov-action/foobar/issues/2/comments", json=checker
     )(status_code=403)
 
-    git.register("git diff --unified=0 origin/foo -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin foo --depth=1000")(stdout=DIFF_STDOUT)
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     result = main.action(
         config=pull_request_config(
@@ -288,7 +290,8 @@ def test_action__pull_request__post_comment(
     # Are there already comments
     session.register("GET", "/repos/py-cov-action/foobar/issues/2/comments")(json=[])
 
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     comment = None
 
@@ -333,7 +336,8 @@ def test_action__push__non_default_branch(
     session.register("GET", "/repos/py-cov-action/foobar")(
         json={"default_branch": "main", "visibility": "public"}
     )
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")(stdout=DIFF_STDOUT)
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     payload = json.dumps({"coverage": 30.00})
     # There is an existing badge in this test, allowing to test the coverage evolution
@@ -402,7 +406,8 @@ def test_action__push__non_default_branch__no_pr(
     session.register("GET", "/repos/py-cov-action/foobar")(
         json={"default_branch": "main", "visibility": "public"}
     )
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")(stdout=DIFF_STDOUT)
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     payload = json.dumps({"coverage": 30.00})
     # There is an existing badge in this test, allowing to test the coverage evolution
@@ -465,7 +470,8 @@ def test_action__pull_request__force_store_comment(
         "/repos/py-cov-action/foobar/contents/data.json",
     )(json={"content": base64.b64encode(payload.encode()).decode()})
 
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     result = main.action(
         config=pull_request_config(FORCE_WORKFLOW_RUN=True, GITHUB_OUTPUT=output_file),
@@ -495,7 +501,8 @@ def test_action__pull_request__post_comment__no_marker(
         "/repos/py-cov-action/foobar/contents/data.json",
     )(status_code=404)
 
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     result = main.action(
         config=pull_request_config(COMMENT_TEMPLATE="""foo"""),
@@ -519,7 +526,8 @@ def test_action__pull_request__annotations(
         "/repos/py-cov-action/foobar/contents/data.json",
     )(status_code=404)
 
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     # Who am I
     session.register("GET", "/user")(json={"login": "foo"})
@@ -560,7 +568,8 @@ def test_action__pull_request__post_comment__template_error(
         "/repos/py-cov-action/foobar/contents/data.json",
     )(status_code=404)
 
-    git.register("git diff --unified=0 origin/main -- .")(stdout=DIFF_STDOUT)
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=DIFF_STDOUT)
 
     result = main.action(
         config=pull_request_config(COMMENT_TEMPLATE="""{%"""),

--- a/tests/unit/test_coverage.py
+++ b/tests/unit/test_coverage.py
@@ -114,3 +114,119 @@ def test_generate_coverage_markdown(mocker):
     ]
 
     assert result == "foo"
+
+
+@pytest.mark.parametrize(
+    "added_lines, executed_lines, missing_lines, expected",
+    [
+        (
+            {pathlib.Path("codebase/code.py"): [1, 3]},
+            [1, 2],
+            [3],
+            coverage.DiffCoverage(
+                total_num_lines=2,
+                total_num_violations=1,
+                total_percent_covered=decimal.Decimal("0.5"),
+                num_changed_lines=2,
+                files={
+                    pathlib.Path("codebase/code.py"): coverage.FileDiffCoverage(
+                        path=pathlib.Path("codebase/code.py"),
+                        percent_covered=decimal.Decimal("0.5"),
+                        violation_lines=[3],
+                    )
+                },
+            ),
+        ),
+        (
+            {pathlib.Path("codebase/code2.py"): [1, 3]},
+            [1, 2],
+            [3],
+            coverage.DiffCoverage(
+                total_num_lines=0,
+                total_num_violations=0,
+                total_percent_covered=decimal.Decimal("1"),
+                num_changed_lines=2,
+                files={},
+            ),
+        ),
+        (
+            {pathlib.Path("codebase/code.py"): [4, 5, 6]},
+            [1, 2, 3],
+            [7],
+            coverage.DiffCoverage(
+                total_num_lines=0,
+                total_num_violations=0,
+                total_percent_covered=decimal.Decimal("1"),
+                num_changed_lines=3,
+                files={
+                    pathlib.Path("codebase/code.py"): coverage.FileDiffCoverage(
+                        path=pathlib.Path("codebase/code.py"),
+                        percent_covered=decimal.Decimal("1"),
+                        violation_lines=[],
+                    )
+                },
+            ),
+        ),
+    ],
+)
+def test_get_diff_coverage_info(
+    coverage_obj_no_branch, added_lines, executed_lines, missing_lines, expected
+):
+    cov_file = coverage_obj_no_branch.files[pathlib.Path("codebase/code.py")]
+    cov_file.executed_lines = executed_lines
+    cov_file.missing_lines = missing_lines
+    result = coverage.get_diff_coverage_info(
+        added_lines=added_lines, coverage=coverage_obj_no_branch
+    )
+    assert result == expected
+
+
+def test_get_added_lines(git):
+    diff = (
+        """+++ b/README.md\n@@ -1,2 +1,3 @@\n-# coverage-comment\n+coverage-comment\n"""
+    )
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=diff)
+    assert coverage.get_added_lines(git=git, base_ref="main") == {
+        pathlib.Path("README.md"): [1, 2, 3]
+    }
+
+
+@pytest.mark.parametrize(
+    "line_number_diff_line, expected",
+    [
+        ("@@ -1,2 +7,4 @@ foo()", [7, 8, 9, 10]),
+        ("@@ -1,2 +8 @@ foo()", [8]),
+    ],
+)
+def test_parse_line_number_diff_line(git, line_number_diff_line, expected):
+    result = list(coverage.parse_line_number_diff_line(line_number_diff_line))
+    assert result == expected
+
+
+def test_parse_diff_output(git):
+    diff = """diff --git a/README.md b/README.md
+index 1f1d9a4..e69de29 100644
+--- a/README.md
++++ b/README.md
+@@ -1 +1 @@
+-# coverage-comment
+-coverage-comment
+@@ -3,2 +3,4 @@
+-foo
+-bar
++foo1
++bar1
++foo2
++bar2
+--- a/foo.txt
++++ b/foo.txt
+@@ -0,0 +1 @@
++bar
+"""
+    git.register("git fetch origin main --depth=1000")()
+    git.register("git diff --unified=0 FETCH_HEAD -- .")(stdout=diff)
+    assert coverage.parse_diff_output(diff=diff) == {
+        pathlib.Path("README.md"): [1, 3, 4, 5, 6],
+        pathlib.Path("foo.txt"): [1],
+    }

--- a/tests/unit/test_template.py
+++ b/tests/unit/test_template.py
@@ -223,7 +223,7 @@ The coverage rate is `75%`.
 <summary>Diff Coverage details (click to unfold)</summary>
 
 ### codebase/code.py
-`80%` of new lines are covered (`75%` of the complete file).
+`80%` of new lines are covered (`83.33%` of the complete file).
 Missing lines: `7`, `9`
 
 </details>


### PR DESCRIPTION
This PR removes diff-cover from the codebase:
- Computes the list of added lines from `git diff`
- Creates a DiffCoverage object from a Coverage object, restricting lines to the ones added
- Recomputes all derived metrics from the base ones

The nice thing is that the tests barely need to change.

We bump the docker image version number in the process, but I believe the old action will run on the new image, and vice versa (thanks to the `pip install .` that we left in `Dockerfile`) so I don't think we need to do anything specific for this to work.