### PR TITLE
Add configuration for autogenerated changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,11 +1,4 @@
 changelog:
-  categories:
-    - title: Features, Bugfixes, etc.
-      labels:
-        - '*'
-      exclude:
-        labels:
-          - dependencies
-    - title: Dependencies
-      labels:
-        - dependencies
+  exclude:
+    labels:
+      - dependencies

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,11 @@
+changelog:
+  categories:
+    - title: Features, Bugfixes, etc.
+      labels:
+        - '*'
+      exclude:
+        labels:
+          - dependencies
+    - title: Dependencies
+      labels:
+        - dependencies

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,7 @@
     "enabled": true,
     "automerge": true,
   },
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchUpdateTypes": [


### PR DESCRIPTION
- Renovate labels its PRs as `dependencies`
- [GitHub sorts](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) PRs with those labels at the bottom **EDIT**: actually, let's remove them. Nobody cares.