### PR TITLE
Workaround pipx bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install Poetry
+        # https://github.com/pypa/pipx/issues/1195
         run: |
-          pipx install poetry --python=python3.11
+          pipx install poetry --python="$(command -v python3.11)"
 
       - name: Poetry caches
         uses: actions/cache@v3

--- a/.github/workflows/e2e-external-phase-2.yml
+++ b/.github/workflows/e2e-external-phase-2.yml
@@ -94,8 +94,9 @@ jobs:
           python-version: "3.11"
 
       - name: Install Poetry
+        # https://github.com/pypa/pipx/issues/1195
         run: |
-          pipx install poetry --python=python3.11
+          pipx install poetry --python="$(command -v python3.11)"
 
       - name: Poetry caches
         uses: actions/cache@v3


### PR DESCRIPTION
Workaround for a [small pipx bug](https://github.com/pypa/pipx/issues/1195) preventing the use of `pipx install --python=` with executables in the path without providing the absolute path to the executable.