### PR TITLE
Improve checks on github.ref fields

### DIFF
--- a/coverage_comment/settings.py
+++ b/coverage_comment/settings.py
@@ -125,14 +125,14 @@ class Config:
     @property
     def GITHUB_PR_NUMBER(self) -> int | None:
         # "refs/pull/2/merge"
-        if "pull" in self.GITHUB_REF:
+        if self.GITHUB_REF.startswith("refs/pull"):
             return int(self.GITHUB_REF.split("/")[2])
         return None
 
     @property
     def GITHUB_BRANCH_NAME(self) -> str | None:
         # "refs/heads/my_branch_name"
-        if "heads" in self.GITHUB_REF:
+        if self.GITHUB_REF.startswith("refs/heads"):
             return self.GITHUB_REF.split("/", 2)[2]
         return None
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -4,6 +4,7 @@ import decimal
 import pathlib
 
 import pytest
+
 from coverage_comment import settings
 
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -4,7 +4,6 @@ import decimal
 import pathlib
 
 import pytest
-
 from coverage_comment import settings
 
 
@@ -127,6 +126,8 @@ def config():
     "github_ref, github_pr_number",
     [
         ("foo", None),
+        ("refs/heads/branch-with-pull", None),
+        ("refs/tags/tag-with-pull", None),
         ("refs/pull/2/merge", 2),
     ],
 )
@@ -138,6 +139,8 @@ def test_config__GITHUB_PR_NUMBER(config, github_ref, github_pr_number):
     "github_ref, github_branch_name",
     [
         ("refs/pull/2/merge", None),
+        ("refs/pull/2/head", None),
+        ("refs/tags/tag-with-heads", None),
         ("refs/heads/a/b", "a/b"),
     ],
 )


### PR DESCRIPTION
This PR arises from the problem of having `"pull"` substring inside your branch name.

In particular, having a branch name like `ISSUE-XXX/task/enable-pull-lorem-ipsum`  causes a crash in the action since  the if inside `GITHUB_PR_NUMBER` property wrongly assumes that `github.ref` refers to a PR, and tries to cast to integer the PR number. 

Goal of this PR is to make the check a bit stronger, for both `GITHUB_PR_NUMBER` and `GITHUB_BRANCH_NAME` (since it's easier to incur in same problem with a tags that contains `"heads"` substring inside it)  checking `github.ref` head rather than randomly checking that a word is inside it.