### PR TITLE
Assert .coverage* files are not ignored in artifact upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ jobs:
         with:
           name: coverage-${{ matrix.python_version }}
           path: .coverage.${{ matrix.python_version }}
+          # By default hidden files/folders (i.e. starting with .) are ignored
+          include-hidden-files: true
 
   coverage:
     name: Coverage


### PR DESCRIPTION
This addresses https://github.com/py-cov-action/python-coverage-comment-action/issues/470