### PR TITLE
Update release workflow to publish to multiple registries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     # Check if the tests were successful and were launched by a push event
     if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    env:
+      IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
@@ -22,11 +29,20 @@ jobs:
           username: ewjoachim
           password: ${{ secrets.DOCKER_PASSWORD }}
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           # See Dockerfile.build for instructions on bumping this.
-          tags: ewjoachim/python-coverage-comment-action-base:v6
+          tags: |
+            ewjoachim/python-coverage-comment-action-base:v6
+            ghcr.io/ewjoachim/python-coverage-comment-action-base:v6
           push: true
           file: Dockerfile.build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           # See Dockerfile.build for instructions on bumping this.
           tags: |
             ewjoachim/python-coverage-comment-action-base:v6
-            ghcr.io/ewjoachim/python-coverage-comment-action-base:v6
+            ghcr.io/py-cov-action/python-coverage-comment-action-base:v6
           push: true
           file: Dockerfile.build
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ jobs:
       packages: write
       attestations: write
       id-token: write
-    env:
-      IMAGE_NAME: ${{ github.repository }}
     steps:
       - name: Log in to Docker Hub
         uses: docker/login-action@v3


### PR DESCRIPTION
Fixes #491 to publish to both Docker Hub and GitHub Container Registry

Based on documentation:

- https://docs.docker.com/build/ci/github-actions/push-multi-registries/
- https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-docker-images
