### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,10 +258,6 @@ jobs:
         run: make test # This is the part where you put your own test command
         env:
           COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
-          # Alternatively you can run coverage with the --parallel flag or add
-          # `parallel = True` in the coverage config file.
-          # If using pytest-cov, you can also add the `--cov-append` flag
-          # directly or through PYTEST_ADD_OPTS.
 
       - name: Store coverage file
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -258,6 +258,10 @@ jobs:
         run: make test # This is the part where you put your own test command
         env:
           COVERAGE_FILE: ".coverage.${{ matrix.python_version }}"
+          # The file name prefix must be ".coverage." for "coverage combine"
+          # enabled by "MERGE_COVERAGE_FILES: true" to work. A "subprocess"
+          # error with the message "No data to combine" will be triggered if
+          # this prefix is not used.
 
       - name: Store coverage file
         uses: actions/upload-artifact@v4
@@ -265,8 +269,10 @@ jobs:
           name: coverage-${{ matrix.python_version }}
           path: .coverage.${{ matrix.python_version }}
           # By default hidden files/folders (i.e. starting with .) are ignored.
-          # You may prefer (for security reason) not setting this and instead
-          # set COVERAGE_FILE above to not start with a `.`
+          # You may prefer (for security reasons) not setting this and instead
+          # set COVERAGE_FILE above to not start with a `.`, but you cannot
+          # use "MERGE_COVERAGE_FILES: true" later on and need to manually
+          # combine the coverage file using "pipx run coverage combine"
           include-hidden-files: true
 
   coverage:


### PR DESCRIPTION
Fix #515 #473 

* Remove comment on using _--parallel_ or _--cov-append_ when a test matrix is used.
* Improve comment on _include-hidden-files_
* Stress the need for _.coverage._ prefix