### PR TITLE
feat: use ghcr image instead of docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # See Dockerfile.build for instructions on bumping this.
-FROM ewjoachim/python-coverage-comment-action-base:v6
+FROM ghcr.io/py-cov-action/python-coverage-comment-action-base:v6
 
 COPY coverage_comment ./coverage_comment
 RUN md5sum -c pyproject.toml.md5 || pip install -e .


### PR DESCRIPTION
Avoid a common issue `429 too many requests` due to the super-low DockerHub unauthenticated pulls limit.
Use GHCR instead.