### PR TITLE
Gracefully handle "diff too large" errors

### DIFF
--- a/coverage_comment/template.py
+++ b/coverage_comment/template.py
@@ -141,6 +141,7 @@ def get_comment_markdown(
     subproject_id: str | None = None,
     custom_template: str | None = None,
     pr_targets_default_branch: bool = True,
+    failure_msg: str | None = None,
 ):
     loader = CommentLoader(base_template=base_template, custom_template=custom_template)
     env = SandboxedEnvironment(loader=loader)
@@ -188,6 +189,7 @@ def get_comment_markdown(
             subproject_id=subproject_id,
             marker=marker,
             pr_targets_default_branch=pr_targets_default_branch,
+            failure_msg=failure_msg,
         )
     except jinja2.exceptions.TemplateError as exc:
         raise TemplateError from exc

--- a/coverage_comment/template_files/comment.md.j2
+++ b/coverage_comment/template_files/comment.md.j2
@@ -19,12 +19,25 @@
 {#- Coverage diff badge -#}
 {#- space #} {# space -#}
 {%- block diff_coverage_badge -%}
+{%- if failure_msg -%}
+<img title="Diff coverage unavailable" src="{{ 'PR Coverage' | generate_badge(message='N/A', color='grey') }}">
+
+{%- else -%}
 {%- set text = (diff_coverage.total_percent_covered | pct) ~ " of the statement lines added by this PR are covered" -%}
 <img title="{{ text }}" src="{{ 'PR Coverage' | generate_badge(message=diff_coverage.total_percent_covered | pct(precision=0), color=diff_coverage.total_percent_covered | x100 | get_badge_color) }}">
 
+{%- endif -%}
 {%- endblock diff_coverage_badge -%}
 {%- endblock coverage_badges -%}
 
+{%- block diff_coverage_failure_message -%}
+{%- if failure_msg %}
+
+> [!WARNING]
+> {{ failure_msg }}
+
+{% endif -%}
+{%- endblock diff_coverage_failure_message -%}
 
 {%- macro statements_badge(path, statements_count, previous_statements_count) -%}
 {% if previous_statements_count is not none -%}


### PR DESCRIPTION
Closes #590. This PR adds an error handler to the diff fetching methods, and will raise a `CannotGetDiff` exception if the too_large GitHub API error is detected. The exception is caught and causes a warning message to be included in the coverage comment, explaining why diff coverage can't be computed.