### PR TITLE
fix: add conventional commit prefix to message

### DIFF
--- a/coverage_comment/storage.py
+++ b/coverage_comment/storage.py
@@ -22,7 +22,7 @@ COMMIT_ENVIRONMENT = {
     "GIT_COMMITTER_NAME": GITHUB_ACTIONS_BOT_NAME,
     "GIT_COMMITTER_EMAIL": GITHUB_ACTIONS_BOT_EMAIL,
 }
-GIT_COMMIT_MESSAGE = "Update coverage data"
+GIT_COMMIT_MESSAGE = "ci: Update coverage data"
 
 
 @contextlib.contextmanager

--- a/tests/integration/test_main.py
+++ b/tests/integration/test_main.py
@@ -623,7 +623,7 @@ def test_action__push__default_branch(
     git.register("git add htmlcov")()
     git.register("git add README.md")()
     git.register("git diff --staged --exit-code")(exit_code=1)
-    git.register("git commit --message Update coverage data")()
+    git.register("git commit --message ci: Update coverage data")()
     git.register("git push origin python-coverage-comment-action-data")()
     git.register("git switch foo")()
 
@@ -692,7 +692,7 @@ def test_action__pull_request_closed_merged(
     git.register("git add htmlcov")()
     git.register("git add README.md")()
     git.register("git diff --staged --exit-code")(exit_code=1)
-    git.register("git commit --message Update coverage data")()
+    git.register("git commit --message ci: Update coverage data")()
     git.register("git push origin python-coverage-comment-action-data")()
     git.register("git switch foo")()
 
@@ -734,7 +734,7 @@ def test_action__push__default_branch__private(
     git.register("git add badge.svg")()
     git.register("git add README.md")()
     git.register("git diff --staged --exit-code")(exit_code=1)
-    git.register("git commit --message Update coverage data")()
+    git.register("git commit --message ci: Update coverage data")()
     git.register("git push origin python-coverage-comment-action-data")()
     git.register("git switch foo")()
 

--- a/tests/unit/test_storage.py
+++ b/tests/unit/test_storage.py
@@ -104,7 +104,7 @@ def test_commit_operations(git, in_tmp_path):
     # (yes, it's missing the quotes, but this is just an artifact from our test
     # double)
     git.register(
-        "git commit --message Update coverage data",
+        "git commit --message ci: Update coverage data",
         env={
             "GIT_AUTHOR_NAME": "github-actions",
             "GIT_AUTHOR_EMAIL": "41898282+github-actions[bot]@users.noreply.github.com",


### PR DESCRIPTION
Fixes to the issue https://github.com/py-cov-action/python-coverage-comment-action/issues/644

This simply adds a prefix to the conventional commit message. This makes the action compatible with repositories that have a standard conventional commit policy.

I will be happy to change the prefix and open to any other feedback.