### PR TITLE
chore: drop the stale zizmor --no-progress workaround

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,5 +59,4 @@ repos:
         language: system
         require_serial: true
         args:
-          - "--no-progress" # https://github.com/zizmorcore/zizmor/issues/582
           - "--persona=auditor"


### PR DESCRIPTION
The `zizmor` hook carries `--no-progress`, pointing at
[zizmorcore/zizmor#582](https://github.com/zizmorcore/zizmor/issues/582). That
issue is closed as **completed** (2025-03-11), and the flag no longer earns its
place here.

### Evidence

**The issue is resolved.** #582 turned out not to be a zizmor bug at all: zizmor
already suppressed the TUI on a non-tty, and the reporter's progress bar came
from `pre-commit.ci` presenting itself *as* a tty. The `--no-progress` escape
hatch was re-added in [#589](https://github.com/zizmorcore/zizmor/pull/589) and
shipped in v1.5.0, for that kind of tty-faking runner.

**The pinned version postdates the fix.** `uv.lock` pins `zizmor==1.29.0`
(2026-08-01), far past v1.5.0 (2025-03-11).

**Non-tty output was checked.** Running the hook the way `make lint` and CI do,
with output captured rather than on a terminal, yields no progress bar — zero
carriage returns, zero erase-line sequences, zero bar glyphs:

```console
$ uv run prek run zizmor --color=always --all-files --verbose > out.txt 2>&1
$ python3 -c "d=open('out.txt','rb').read(); print('CR:', d.count(b'\r'), 'ESC[2K:', d.count(b'\x1b[2K'))"
CR: 0 ESC[2K: 0
```

```
zizmor...................................................................Passed
- hook id: zizmor
- duration: 0.12s

   INFO zizmor: 🌈 zizmor v1.29.0
   WARN audit: zizmor: zizmor is running in offline mode by default; ...
   INFO audit: zizmor: 🌈 completed .github/workflows/autofix.yml
   ...
  No findings to report. Good job! (10 ignored)
  No fixes available to apply.
```

Worth noting `--color=always` does not reintroduce the problem: prek forces
colour through the environment rather than by allocating a pty, so the log lines
come out coloured while the progress bar stays suppressed. Attaching prek itself
to a real pty behaves the same — the only carriage returns belong to prek's own
"Running hooks..." spinner. For contrast, giving *zizmor* a genuine pty
(`script -q out.txt uv run zizmor ...`) does produce the full TUI — 338 carriage
returns, 327 erase-line sequences — so this is about the hook's environment, not
about zizmor having dropped the feature.

`uv run prek run --show-diff-on-failure --color=always --all-files` passes, all
eleven hooks green.

### Checklist:
- [x] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [x] (not applicable?)

🤖 Generated with [Claude Code](https://claude.com/claude-code)